### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Deny everything.
+**
+
+!/LICENSE
+!/docker-entrypoint.sh
+
+!/hasura/**
+# /hasura/** covers the following files so ignore them explicitly.
+/hasura/.env
+/hasura/config.yaml


### PR DESCRIPTION
Currently the Dockerfile is explicit about the files it copies. Yet the Docker building context has extra files in it. This is just to tidy those away.

This `.dockerignore` defaults to deny, to ignore. That means that in the future new files that need to be included in the Dockerfile need to be added into `.dockerignore`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/9)
<!-- Reviewable:end -->
