### PR TITLE
Add function for resolving closest link for point

### DIFF
--- a/metadata/databases/databases.yaml
+++ b/metadata/databases/databases.yaml
@@ -12,3 +12,4 @@
         retries: 1
       use_prepared_statements: true
   tables: "!include default/tables/tables.yaml"
+  functions: "!include default/functions/functions.yaml"

--- a/metadata/databases/default/functions/functions.yaml
+++ b/metadata/databases/default/functions/functions.yaml
@@ -1,0 +1,1 @@
+- "!include infrastructure_network_resolve_point_to_closest_link.yaml"

--- a/metadata/databases/default/functions/infrastructure_network_resolve_point_to_closest_link.yaml
+++ b/metadata/databases/default/functions/infrastructure_network_resolve_point_to_closest_link.yaml
@@ -1,0 +1,3 @@
+function:
+  name: resolve_point_to_closest_link
+  schema: infrastructure_network

--- a/migrations/default/1636020998063_add_resolve_point_to_closest_link_function/down.sql
+++ b/migrations/default/1636020998063_add_resolve_point_to_closest_link_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION infrastructure_network.resolve_point_to_closest_link;

--- a/migrations/default/1636020998063_add_resolve_point_to_closest_link_function/up.sql
+++ b/migrations/default/1636020998063_add_resolve_point_to_closest_link_function/up.sql
@@ -1,0 +1,28 @@
+CREATE FUNCTION infrastructure_network.resolve_point_to_closest_link(
+  geog geography
+)
+RETURNS SETOF infrastructure_network.infrastructure_link
+LANGUAGE sql
+STABLE
+STRICT
+PARALLEL SAFE
+AS $infrastructure_network_resolve_point_to_closest_link$
+SELECT link.*
+FROM (
+    SELECT geog
+) point_of_interest
+CROSS JOIN LATERAL (
+    SELECT
+        link.infrastructure_link_id,
+        point_of_interest.geog <-> link.shape AS distance
+    FROM infrastructure_network.infrastructure_link link
+    WHERE ST_DWithin(point_of_interest.geog, link.shape, 100) -- link filtering radius set to 100 m
+    ORDER BY distance
+    LIMIT 1
+) closest_link_result
+INNER JOIN infrastructure_network.infrastructure_link link ON link.infrastructure_link_id = closest_link_result.infrastructure_link_id;
+$infrastructure_network_resolve_point_to_closest_link$;
+
+COMMENT ON FUNCTION
+  infrastructure_network.resolve_point_to_closest_link(geography) IS
+  'Function for resolving closest infrastructure link to the given point of interest.';


### PR DESCRIPTION
Example query about function usage. Seems to work at least
in hasura console:
```
query MyQuery {
  infrastructure_network_resolve_point_to_closest_link(args: {geog: {type: "Point", coordinates: [24.939316517, 60.170981403]}}) {
    estimated_length_in_metres
    external_link_id
    infrastructure_link_id
  }
}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/25)
<!-- Reviewable:end -->

Resolves https://github.com/HSLdevcom/jore4/issues/529