### PR TITLE
Fix jore3 importer db username in migrations

### DIFF
--- a/migrations/default/1636618341769_grant_permissions_to_importer_user/down.sql
+++ b/migrations/default/1636618341769_grant_permissions_to_importer_user/down.sql
@@ -1,29 +1,29 @@
-REVOKE SELECT ON ALL TABLES IN SCHEMA service_pattern FROM dbimporter;
-REVOKE INSERT ON ALL TABLES IN SCHEMA service_pattern FROM dbimporter;
-REVOKE UPDATE ON ALL TABLES IN SCHEMA service_pattern FROM dbimporter;
-REVOKE DELETE ON ALL TABLES IN SCHEMA service_pattern FROM dbimporter;
-REVOKE TRUNCATE ON ALL TABLES IN SCHEMA service_pattern FROM dbimporter;
+REVOKE SELECT ON ALL TABLES IN SCHEMA service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE INSERT ON ALL TABLES IN SCHEMA service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE UPDATE ON ALL TABLES IN SCHEMA service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE DELETE ON ALL TABLES IN SCHEMA service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA service_pattern FROM xxx_db_jore3importer_username_xxx;
 
-REVOKE SELECT ON ALL TABLES IN SCHEMA journey_pattern FROM dbimporter;
-REVOKE INSERT ON ALL TABLES IN SCHEMA journey_pattern FROM dbimporter;
-REVOKE UPDATE ON ALL TABLES IN SCHEMA journey_pattern FROM dbimporter;
-REVOKE DELETE ON ALL TABLES IN SCHEMA journey_pattern FROM dbimporter;
-REVOKE TRUNCATE ON ALL TABLES IN SCHEMA journey_pattern FROM dbimporter;
+REVOKE SELECT ON ALL TABLES IN SCHEMA journey_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE INSERT ON ALL TABLES IN SCHEMA journey_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE UPDATE ON ALL TABLES IN SCHEMA journey_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE DELETE ON ALL TABLES IN SCHEMA journey_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA journey_pattern FROM xxx_db_jore3importer_username_xxx;
 
-REVOKE SELECT ON ALL TABLES IN SCHEMA internal_service_pattern FROM dbimporter;
-REVOKE INSERT ON ALL TABLES IN SCHEMA internal_service_pattern FROM dbimporter;
-REVOKE UPDATE ON ALL TABLES IN SCHEMA internal_service_pattern FROM dbimporter;
-REVOKE DELETE ON ALL TABLES IN SCHEMA internal_service_pattern FROM dbimporter;
-REVOKE TRUNCATE ON ALL TABLES IN SCHEMA internal_service_pattern FROM dbimporter;
+REVOKE SELECT ON ALL TABLES IN SCHEMA internal_service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE INSERT ON ALL TABLES IN SCHEMA internal_service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE UPDATE ON ALL TABLES IN SCHEMA internal_service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE DELETE ON ALL TABLES IN SCHEMA internal_service_pattern FROM xxx_db_jore3importer_username_xxx;
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA internal_service_pattern FROM xxx_db_jore3importer_username_xxx;
 
-REVOKE SELECT ON ALL TABLES IN SCHEMA internal_route FROM dbimporter;
-REVOKE INSERT ON ALL TABLES IN SCHEMA internal_route FROM dbimporter;
-REVOKE UPDATE ON ALL TABLES IN SCHEMA internal_route FROM dbimporter;
-REVOKE DELETE ON ALL TABLES IN SCHEMA internal_route FROM dbimporter;
-REVOKE TRUNCATE ON ALL TABLES IN SCHEMA internal_route FROM dbimporter;
+REVOKE SELECT ON ALL TABLES IN SCHEMA internal_route FROM xxx_db_jore3importer_username_xxx;
+REVOKE INSERT ON ALL TABLES IN SCHEMA internal_route FROM xxx_db_jore3importer_username_xxx;
+REVOKE UPDATE ON ALL TABLES IN SCHEMA internal_route FROM xxx_db_jore3importer_username_xxx;
+REVOKE DELETE ON ALL TABLES IN SCHEMA internal_route FROM xxx_db_jore3importer_username_xxx;
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA internal_route FROM xxx_db_jore3importer_username_xxx;
 
-REVOKE SELECT ON ALL TABLES IN SCHEMA route FROM dbimporter;
-REVOKE INSERT ON ALL TABLES IN SCHEMA route FROM dbimporter;
-REVOKE UPDATE ON ALL TABLES IN SCHEMA route FROM dbimporter;
-REVOKE DELETE ON ALL TABLES IN SCHEMA route FROM dbimporter;
-REVOKE TRUNCATE ON ALL TABLES IN SCHEMA route FROM dbimporter;
+REVOKE SELECT ON ALL TABLES IN SCHEMA route FROM xxx_db_jore3importer_username_xxx;
+REVOKE INSERT ON ALL TABLES IN SCHEMA route FROM xxx_db_jore3importer_username_xxx;
+REVOKE UPDATE ON ALL TABLES IN SCHEMA route FROM xxx_db_jore3importer_username_xxx;
+REVOKE DELETE ON ALL TABLES IN SCHEMA route FROM xxx_db_jore3importer_username_xxx;
+REVOKE TRUNCATE ON ALL TABLES IN SCHEMA route FROM xxx_db_jore3importer_username_xxx;

--- a/migrations/default/1636618341769_grant_permissions_to_importer_user/up.sql
+++ b/migrations/default/1636618341769_grant_permissions_to_importer_user/up.sql
@@ -1,29 +1,29 @@
-GRANT SELECT ON ALL TABLES IN SCHEMA service_pattern TO dbimporter;
-GRANT INSERT ON ALL TABLES IN SCHEMA service_pattern TO dbimporter;
-GRANT UPDATE ON ALL TABLES IN SCHEMA service_pattern TO dbimporter;
-GRANT DELETE ON ALL TABLES IN SCHEMA service_pattern TO dbimporter;
-GRANT TRUNCATE ON ALL TABLES IN SCHEMA service_pattern TO dbimporter;
+GRANT SELECT ON ALL TABLES IN SCHEMA service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT INSERT ON ALL TABLES IN SCHEMA service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT UPDATE ON ALL TABLES IN SCHEMA service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT DELETE ON ALL TABLES IN SCHEMA service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT TRUNCATE ON ALL TABLES IN SCHEMA service_pattern TO xxx_db_jore3importer_username_xxx;
 
-GRANT SELECT ON ALL TABLES IN SCHEMA journey_pattern TO dbimporter;
-GRANT INSERT ON ALL TABLES IN SCHEMA journey_pattern TO dbimporter;
-GRANT UPDATE ON ALL TABLES IN SCHEMA journey_pattern TO dbimporter;
-GRANT DELETE ON ALL TABLES IN SCHEMA journey_pattern TO dbimporter;
-GRANT TRUNCATE ON ALL TABLES IN SCHEMA journey_pattern TO dbimporter;
+GRANT SELECT ON ALL TABLES IN SCHEMA journey_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT INSERT ON ALL TABLES IN SCHEMA journey_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT UPDATE ON ALL TABLES IN SCHEMA journey_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT DELETE ON ALL TABLES IN SCHEMA journey_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT TRUNCATE ON ALL TABLES IN SCHEMA journey_pattern TO xxx_db_jore3importer_username_xxx;
 
-GRANT SELECT ON ALL TABLES IN SCHEMA internal_service_pattern TO dbimporter;
-GRANT INSERT ON ALL TABLES IN SCHEMA internal_service_pattern TO dbimporter;
-GRANT UPDATE ON ALL TABLES IN SCHEMA internal_service_pattern TO dbimporter;
-GRANT DELETE ON ALL TABLES IN SCHEMA internal_service_pattern TO dbimporter;
-GRANT TRUNCATE ON ALL TABLES IN SCHEMA internal_service_pattern TO dbimporter;
+GRANT SELECT ON ALL TABLES IN SCHEMA internal_service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT INSERT ON ALL TABLES IN SCHEMA internal_service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT UPDATE ON ALL TABLES IN SCHEMA internal_service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT DELETE ON ALL TABLES IN SCHEMA internal_service_pattern TO xxx_db_jore3importer_username_xxx;
+GRANT TRUNCATE ON ALL TABLES IN SCHEMA internal_service_pattern TO xxx_db_jore3importer_username_xxx;
 
-GRANT SELECT ON ALL TABLES IN SCHEMA internal_route TO dbimporter;
-GRANT INSERT ON ALL TABLES IN SCHEMA internal_route TO dbimporter;
-GRANT UPDATE ON ALL TABLES IN SCHEMA internal_route TO dbimporter;
-GRANT DELETE ON ALL TABLES IN SCHEMA internal_route TO dbimporter;
-GRANT TRUNCATE ON ALL TABLES IN SCHEMA internal_route TO dbimporter;
+GRANT SELECT ON ALL TABLES IN SCHEMA internal_route TO xxx_db_jore3importer_username_xxx;
+GRANT INSERT ON ALL TABLES IN SCHEMA internal_route TO xxx_db_jore3importer_username_xxx;
+GRANT UPDATE ON ALL TABLES IN SCHEMA internal_route TO xxx_db_jore3importer_username_xxx;
+GRANT DELETE ON ALL TABLES IN SCHEMA internal_route TO xxx_db_jore3importer_username_xxx;
+GRANT TRUNCATE ON ALL TABLES IN SCHEMA internal_route TO xxx_db_jore3importer_username_xxx;
 
-GRANT SELECT ON ALL TABLES IN SCHEMA route TO dbimporter;
-GRANT INSERT ON ALL TABLES IN SCHEMA route TO dbimporter;
-GRANT UPDATE ON ALL TABLES IN SCHEMA route TO dbimporter;
-GRANT DELETE ON ALL TABLES IN SCHEMA route TO dbimporter;
-GRANT TRUNCATE ON ALL TABLES IN SCHEMA route TO dbimporter;
+GRANT SELECT ON ALL TABLES IN SCHEMA route TO xxx_db_jore3importer_username_xxx;
+GRANT INSERT ON ALL TABLES IN SCHEMA route TO xxx_db_jore3importer_username_xxx;
+GRANT UPDATE ON ALL TABLES IN SCHEMA route TO xxx_db_jore3importer_username_xxx;
+GRANT DELETE ON ALL TABLES IN SCHEMA route TO xxx_db_jore3importer_username_xxx;
+GRANT TRUNCATE ON ALL TABLES IN SCHEMA route TO xxx_db_jore3importer_username_xxx;

--- a/migrations/default/1636627179809_drop_unnecessary_schemas/down.sql
+++ b/migrations/default/1636627179809_drop_unnecessary_schemas/down.sql
@@ -2,4 +2,4 @@ CREATE SCHEMA auth_session;
 GRANT ALL PRIVILEGES ON SCHEMA auth_session TO dbauth;
 
 CREATE SCHEMA import_jore3;
-GRANT ALL PRIVILEGES ON SCHEMA import_jore3 TO dbimporter;
+GRANT ALL PRIVILEGES ON SCHEMA import_jore3 TO xxx_db_jore3importer_username_xxx;


### PR DESCRIPTION
Before, the name "dbimporter" was used, which does not work in cloud
environments. There, the xxx_db_jore3importer_username_xxx placeholder
has to be used, which will be replaced with the appropriate username at
run-time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/33)
<!-- Reviewable:end -->
