### PR TITLE
Allow multiple overlapping draft versions

### DIFF
--- a/integration-test/datasets/defaultSetup/routes.ts
+++ b/integration-test/datasets/defaultSetup/routes.ts
@@ -45,6 +45,15 @@ export const routes: Route[] = [
     validity_start: new Date('2044-01-02 21:11:32Z'),
     validity_end: new Date('2044-09-02 22:11:32Z'),
   },
+  {
+    route_id: '7dac4416-1f84-4951-86b7-169d00bcd8d9',
+    on_line_id: lines[4].line_id,
+    ...buildRoute('5'),
+    direction: RouteDirection.Eastbound,
+    priority: 20,
+    validity_start: null,
+    validity_end: new Date('2044-09-02 23:11:32Z'),
+  },
 ];
 
 export const infrastructureLinkAlongRoute: InfrastructureLinkAlongRoute[] = [

--- a/integration-test/datasets/defaultSetup/scheduled-stop-points.ts
+++ b/integration-test/datasets/defaultSetup/scheduled-stop-points.ts
@@ -59,7 +59,7 @@ export const scheduledStopPoints: ScheduledStopPoint[] = [
       },
     },
     label: 'stop2',
-    priority: 30,
+    priority: 20,
     validity_start: null,
     validity_end: new Date('2064-01-03 12:34:56'),
   },

--- a/integration-test/tests/priority-and-validity-period-constraints/line/insert-without-conflicts.spec.ts
+++ b/integration-test/tests/priority-and-validity-period-constraints/line/insert-without-conflicts.spec.ts
@@ -87,7 +87,7 @@ describe('Insert line', () => {
       ...buildLine('34', VehicleMode.Tram),
       name_i18n: buildLocalizedString('conflicting transport tram line 34'),
       short_name_i18n: buildLocalizedString('conflicting line 34'),
-      priority: 30,
+      priority: 10,
       validity_start: new Date('2041-06-01 23:11:32Z'),
       validity_end: new Date('2042-06-01 23:11:32Z'),
     };
@@ -144,9 +144,22 @@ describe('Insert line', () => {
   describe('whose validity period is entirely contained in other validity period but has different priority', () => {
     const toBeInserted: Partial<Line> = {
       ...buildLine('2', VehicleMode.Bus),
-      priority: 30,
+      priority: 20,
       validity_start: new Date('2044-06-01 23:11:32Z'),
       validity_end: new Date('2045-04-01 23:11:32Z'),
+    };
+
+    shouldReturnCorrectResponse(toBeInserted);
+
+    shouldInsertCorrectRowIntoDatabase(toBeInserted);
+  });
+
+  describe('whose validity period is entirely contained in other validity period but both have draft priority', () => {
+    const toBeInserted: Partial<Line> = {
+      ...buildLine('77', VehicleMode.Tram),
+      priority: 30,
+      validity_start: new Date('2043-06-01 23:11:32Z'),
+      validity_end: new Date('2044-04-01 23:11:32Z'),
     };
 
     shouldReturnCorrectResponse(toBeInserted);

--- a/integration-test/tests/priority-and-validity-period-constraints/route/insert-with-conflicts.spec.ts
+++ b/integration-test/tests/priority-and-validity-period-constraints/route/insert-with-conflicts.spec.ts
@@ -60,10 +60,10 @@ describe('Insert route', () => {
 
   describe('whose validity period conflicts with open validity start', () => {
     const toBeInserted: Partial<Route> = {
-      ...buildRoute('3'),
-      on_line_id: lines[2].line_id,
+      ...buildRoute('5'),
+      on_line_id: lines[4].line_id,
       direction: RouteDirection.Eastbound,
-      priority: 30,
+      priority: 20,
       validity_start: new Date('2024-09-02 23:11:32Z'),
       validity_end: new Date('2034-09-02 23:11:32Z'),
     };
@@ -75,11 +75,11 @@ describe('Insert route', () => {
 
   describe('whose validity period overlaps partially with existing validity period', () => {
     const toBeInserted: Partial<Route> = {
-      ...buildRoute('3'),
+      ...buildRoute('2'),
       on_line_id: lines[1].line_id,
       direction: RouteDirection.Eastbound,
-      priority: 30,
-      validity_start: new Date('2044-08-02 23:11:32Z'),
+      priority: 20,
+      validity_start: new Date('2044-04-02 23:11:32Z'),
       validity_end: new Date('2044-10-02 23:11:32Z'),
     };
 

--- a/integration-test/tests/priority-and-validity-period-constraints/route/insert-without-conflicts.spec.ts
+++ b/integration-test/tests/priority-and-validity-period-constraints/route/insert-without-conflicts.spec.ts
@@ -100,11 +100,11 @@ describe('Insert route', () => {
 
   describe('whose validity period conflicts with open validity start but has different label', () => {
     const toBeInserted: Partial<Route> = {
-      ...buildRoute('3'),
-      on_line_id: lines[2].line_id,
+      ...buildRoute('5'),
+      on_line_id: lines[4].line_id,
       label: 'route 3X',
       direction: RouteDirection.Eastbound,
-      priority: 30,
+      priority: 20,
       validity_start: new Date('2024-09-02 23:11:32Z'),
       validity_end: new Date('2034-09-02 23:11:32Z'),
     };
@@ -116,10 +116,10 @@ describe('Insert route', () => {
 
   describe('whose validity period does not conflict with open validity start', () => {
     const toBeInserted: Partial<Route> = {
-      ...buildRoute('3'),
-      on_line_id: lines[2].line_id,
+      ...buildRoute('5'),
+      on_line_id: lines[4].line_id,
       direction: RouteDirection.Eastbound,
-      priority: 30,
+      priority: 20,
       validity_start: new Date('2044-09-02 23:11:32Z'),
       validity_end: new Date('2045-06-01 23:11:32Z'),
     };
@@ -152,6 +152,21 @@ describe('Insert route', () => {
       priority: 20,
       validity_start: new Date('2044-04-02 21:11:32Z'),
       validity_end: new Date('2044-08-02 22:11:32Z'),
+    };
+
+    shouldReturnCorrectResponse(toBeInserted);
+
+    shouldInsertCorrectRowIntoDatabase(toBeInserted);
+  });
+
+  describe('whose validity period overlaps with existing validity but both have draft priority', () => {
+    const toBeInserted: Partial<Route> = {
+      ...buildRoute('3'),
+      on_line_id: lines[2].line_id,
+      direction: RouteDirection.Eastbound,
+      priority: 30,
+      validity_start: new Date('2042-09-02 23:11:32Z'),
+      validity_end: new Date('2043-09-02 23:11:32Z'),
     };
 
     shouldReturnCorrectResponse(toBeInserted);

--- a/integration-test/tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-with-conflicts.spec.ts
+++ b/integration-test/tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-with-conflicts.spec.ts
@@ -95,7 +95,7 @@ describe('Insert scheduled stop point', () => {
         },
       },
       label: 'stop2',
-      priority: 30,
+      priority: 20,
       validity_start: new Date('2062-01-03 12:34:56'),
       validity_end: new Date('2063-01-03 12:34:56'),
     };

--- a/integration-test/tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-without-conflicts.spec.ts
+++ b/integration-test/tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-without-conflicts.spec.ts
@@ -121,7 +121,7 @@ describe('Insert scheduled stop point', () => {
         },
       },
       label: 'stop2',
-      priority: 20,
+      priority: 10,
       validity_start: new Date('2062-01-03 12:34:56'),
       validity_end: new Date('2063-01-03 12:34:56'),
     };
@@ -220,6 +220,30 @@ describe('Insert scheduled stop point', () => {
       priority: 20,
       validity_start: new Date('2065-01-05 12:34:56'),
       validity_end: new Date('2065-01-08 12:34:56'),
+    };
+
+    shouldReturnCorrectResponse(toBeInserted);
+
+    shouldInsertCorrectRowIntoDatabase(toBeInserted);
+  });
+
+  describe('whose validity period is entirely contained in other validity period but both have draft priority', () => {
+    const toBeInserted: Partial<ScheduledStopPoint> = {
+      located_on_infrastructure_link_id:
+        infrastructureLinks[5].infrastructure_link_id,
+      direction: LinkDirection.Forward,
+      measured_location: {
+        type: 'Point',
+        coordinates: [12.1, 11.2, 0],
+        crs: {
+          properties: { name: 'urn:ogc:def:crs:EPSG::4326' },
+          type: 'name',
+        },
+      },
+      label: 'stopZ2',
+      priority: 30,
+      validity_start: new Date('2063-01-05 12:34:56'),
+      validity_end: new Date('2064-01-08 12:34:56'),
     };
 
     shouldReturnCorrectResponse(toBeInserted);

--- a/migrations/generic/default/1656589426778_constant_values_for_priorities/down.sql
+++ b/migrations/generic/default/1656589426778_constant_values_for_priorities/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION internal_utils.const_priority_draft;

--- a/migrations/generic/default/1656589426778_constant_values_for_priorities/up.sql
+++ b/migrations/generic/default/1656589426778_constant_values_for_priorities/up.sql
@@ -1,0 +1,3 @@
+CREATE FUNCTION internal_utils.const_priority_draft()
+  RETURNS int LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+'SELECT 30';

--- a/migrations/generic/default/1656589426929_allow_multiple_overlapping_drafts/down.sql
+++ b/migrations/generic/default/1656589426929_allow_multiple_overlapping_drafts/down.sql
@@ -1,0 +1,30 @@
+ALTER TABLE internal_service_pattern.scheduled_stop_point
+DROP CONSTRAINT unique_validity_period;
+
+ALTER TABLE internal_service_pattern.scheduled_stop_point
+ADD CONSTRAINT unique_validity_period EXCLUDE USING GIST (
+  label WITH =,
+  priority WITH =,
+  TSTZRANGE(validity_start, validity_end) WITH &&
+);
+
+ALTER TABLE route.route
+DROP CONSTRAINT route_unique_validity_period;
+
+ALTER TABLE route.route
+ADD CONSTRAINT route_unique_validity_period EXCLUDE USING GIST (
+  label WITH =,
+  direction WITH =,
+  priority WITH =,
+  TSTZRANGE(validity_start, validity_end) WITH &&
+);
+
+ALTER TABLE route.line
+DROP CONSTRAINT line_unique_validity_period;
+
+ALTER TABLE route.line
+ADD CONSTRAINT line_unique_validity_period EXCLUDE USING GIST (
+  label WITH =,
+  priority WITH =,
+  TSTZRANGE(validity_start, validity_end) WITH &&
+);

--- a/migrations/generic/default/1656589426929_allow_multiple_overlapping_drafts/up.sql
+++ b/migrations/generic/default/1656589426929_allow_multiple_overlapping_drafts/up.sql
@@ -1,0 +1,35 @@
+
+
+ALTER TABLE internal_service_pattern.scheduled_stop_point
+DROP CONSTRAINT unique_validity_period;
+
+ALTER TABLE internal_service_pattern.scheduled_stop_point
+ADD CONSTRAINT unique_validity_period EXCLUDE USING GIST (
+  label WITH =,
+  priority WITH =,
+  TSTZRANGE(validity_start, validity_end) WITH &&
+)
+WHERE (priority < internal_utils.const_priority_draft());
+
+ALTER TABLE route.route
+DROP CONSTRAINT route_unique_validity_period;
+
+ALTER TABLE route.route
+ADD CONSTRAINT route_unique_validity_period EXCLUDE USING GIST (
+  label WITH =,
+  direction WITH =,
+  priority WITH =,
+  TSTZRANGE(validity_start, validity_end) WITH &&
+)
+WHERE (priority < internal_utils.const_priority_draft());
+
+ALTER TABLE route.line
+DROP CONSTRAINT line_unique_validity_period;
+
+ALTER TABLE route.line
+ADD CONSTRAINT line_unique_validity_period EXCLUDE USING GIST (
+  label WITH =,
+  priority WITH =,
+  TSTZRANGE(validity_start, validity_end) WITH &&
+)
+WHERE (priority < internal_utils.const_priority_draft());


### PR DESCRIPTION
Allow overlapping draft versions of stop points, routes and lines to exist in the database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/83)
<!-- Reviewable:end -->
