### PR TITLE
Rename relationship to correctly represent the dimensions

### DIFF
--- a/metadata/generic/databases/default/tables/infrastructure_network_infrastructure_link.yaml
+++ b/metadata/generic/databases/default/tables/infrastructure_network_infrastructure_link.yaml
@@ -16,7 +16,7 @@ array_relationships:
         table:
           name: infrastructure_link_along_route
           schema: route
-  - name: scheduled_stop_point_located_on_infrastructure_link
+  - name: scheduled_stop_points_located_on_infrastructure_link
     using:
       manual_configuration:
         column_mapping:


### PR DESCRIPTION
There can be multiple scheduled stop points along an infrastructure link, thus changed it to plural

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/86)
<!-- Reviewable:end -->
