### PR TITLE
Add relationship to see different versions of a scheduled stop point

### DIFF
--- a/metadata/generic/databases/default/tables/service_pattern_scheduled_stop_point.yaml
+++ b/metadata/generic/databases/default/tables/service_pattern_scheduled_stop_point.yaml
@@ -11,6 +11,15 @@ array_relationships:
         insertion_order: null
         column_mapping:
           label: scheduled_stop_point_label
+  - name: other_label_instances
+    using:
+      manual_configuration:
+        remote_table:
+          schema: service_pattern
+          name: scheduled_stop_point
+        insertion_order: null
+        column_mapping:
+          label: label
   - name: vehicle_mode_on_scheduled_stop_point
     using:
       manual_configuration:


### PR DESCRIPTION
The scheduled_stop_point_versions relationship fetches all the scheduled stop points with the same label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/87)
<!-- Reviewable:end -->
