### PR TITLE
Change route_shape calculation to use ST_MakeLine

### DIFF
--- a/migrations/generic/default/1660903023968_change_route_shape_calculation_to_use_make_line/down.sql
+++ b/migrations/generic/default/1660903023968_change_route_shape_calculation_to_use_make_line/down.sql
@@ -1,0 +1,8 @@
+DROP FUNCTION route.route_shape(route_row route.route);
+
+ALTER FUNCTION deleted.route_shape_1660903023968(route_row route.route)
+    SET SCHEMA route;
+     
+ALTER FUNCTION route.route_shape_1660903023968
+(route_row route.route)
+RENAME TO route_shape;

--- a/migrations/generic/default/1660903023968_change_route_shape_calculation_to_use_make_line/up.sql
+++ b/migrations/generic/default/1660903023968_change_route_shape_calculation_to_use_make_line/up.sql
@@ -1,0 +1,28 @@
+ALTER FUNCTION route.route_shape
+(route_row route.route)
+RENAME TO route_shape_1660903023968;
+
+ALTER FUNCTION route.route_shape_1660903023968(route_row route.route)
+    SET SCHEMA deleted;
+
+-- Change the route_shape calculating function to use 'ST_MakeLine' to 
+-- get only LineStrings as result of route_shape
+CREATE FUNCTION route.route_shape(route_row route.route)
+RETURNS geography AS $route_shape$
+  SELECT
+    ST_MakeLine(
+      CASE
+        WHEN ilar.is_traversal_forwards THEN il.shape::geometry
+        ELSE ST_Reverse(il.shape::geometry)
+      END
+        ORDER BY ilar.infrastructure_link_sequence
+    )::geography AS route_shape
+  FROM
+    route.route r
+      LEFT JOIN (
+      route.infrastructure_link_along_route AS ilar
+        INNER JOIN infrastructure_network.infrastructure_link AS il
+        ON (ilar.infrastructure_link_id = il.infrastructure_link_id)
+      ) ON (route_row.route_id = ilar.route_id)
+    WHERE r.route_id = route_row.route_id;
+$route_shape$ LANGUAGE sql STABLE;


### PR DESCRIPTION
There are cases when ST_LineMerge & ST_Collect creates a MultiLineString as result, which is preferably not the result what we want. We can use ST_MakeLine to always get LineString as result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/91)
<!-- Reviewable:end -->
