### PR TITLE
Add priority to timetables

### DIFF
--- a/migrations/generic/timetables/1663231564515_timetables_initial/up.sql
+++ b/migrations/generic/timetables/1663231564515_timetables_initial/up.sql
@@ -67,12 +67,14 @@ CREATE TABLE vehicle_schedule.vehicle_schedule_frame (
   vehicle_schedule_frame_id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
   name_i18n jsonb NOT NULL,
   validity_start date NULL,
-  validity_end date NULL
+  validity_end date NULL,
+  priority int NOT NULL
 );
 COMMENT ON TABLE vehicle_schedule.vehicle_schedule_frame IS 'A coherent set of BLOCKS, COMPOUND BLOCKs, COURSEs of JOURNEY and VEHICLE SCHEDULEs to which the same set of VALIDITY CONDITIONs have been assigned. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:7:2:993 ';
 COMMENT ON COLUMN vehicle_schedule.vehicle_schedule_frame.name_i18n IS 'Human-readable name for the VEHICLE SCHEDULE FRAME';
 COMMENT ON COLUMN vehicle_schedule.vehicle_schedule_frame.validity_start IS 'OPERATING DAY when the VEHICLE SCHEDULE FRAME validity starts. Null if always has been valid.';
 COMMENT ON COLUMN vehicle_schedule.vehicle_schedule_frame.validity_end IS 'OPERATING DAY when the VEHICLE SCHEDULE FRAME validity end. Null if always will be valid.';
+COMMENT ON COLUMN vehicle_schedule.vehicle_schedule_frame.priority IS 'The priority of the timetable definition. The definition may be overridden by higher priority definitions.';
 
 -------------------- Vehicle Service --------------------
 
@@ -84,7 +86,7 @@ CREATE TABLE vehicle_service.vehicle_service (
   day_type_id uuid REFERENCES service_calendar.day_type (day_type_id) NOT NULL,
   vehicle_schedule_frame_id uuid REFERENCES vehicle_schedule.vehicle_schedule_frame (vehicle_schedule_frame_id) NOT NULL
 );
-COMMENT ON TABLE vehicle_service.vehicle_service IS 'A work plan for a single vehicle for a whole day, planned for a specific DAY TYPE. A VEHICLE SERVICE includes one or several VEHICLE SERVICE PARTs. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:5:965 ';
+COMMENT ON TABLE vehicle_service.vehicle_service IS 'A work plan for a single vehicle for a whole day, planned for a specific DAY TYPE. A VEHICLE SERVICE includes one or several BLOCKs. If there is no service on a given day, it does not include any BLOCKs. Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:5:965 ';
 COMMENT ON COLUMN vehicle_service.vehicle_service.day_type_id IS 'The DAY TYPE for the VEHICLE SERVICE.';
 COMMENT ON COLUMN vehicle_service.vehicle_service.vehicle_schedule_frame_id IS 'Human-readable name for the VEHICLE SCHEDULE FRAME';
 

--- a/migrations/seed-data/timetables/2524600900000_seed-timetables/up.sql
+++ b/migrations/seed-data/timetables/2524600900000_seed-timetables/up.sql
@@ -20,9 +20,9 @@ VALUES
 ON CONFLICT DO NOTHING;
 
 INSERT INTO vehicle_schedule.vehicle_schedule_frame
-  (vehicle_schedule_frame_id, name_i18n, validity_start, validity_end)
+  (vehicle_schedule_frame_id, name_i18n, validity_start, validity_end, priority)
 VALUES
-  ('10ed8438-878b-4549-82f4-134127824231', '{"fi_FI": "2022 Syksy - 2022 Kevät", "sv_FI": "2022 Höst - 2022 Vår"}', '2022-08-15', '2023-06-04')
+  ('10ed8438-878b-4549-82f4-134127824231', '{"fi_FI": "2022 Syksy - 2022 Kevät", "sv_FI": "2022 Höst - 2022 Vår"}', '2022-08-15', '2023-06-04', 10)
 ON CONFLICT DO NOTHING;
 
 INSERT INTO vehicle_service.vehicle_service


### PR DESCRIPTION
For now, we only define priority on the timetable (VEHICLE SCHEDULE FRAME) level. This affects all contained entities within (VEHICLE SERVICE, VEHICLE JOURNEY, etc).
Timetable priorities are evaluated on an OPERATING DAY basis: if on the given OPERATING DAY another active, higher priority version is found, then that timetable will take precedence for that given day.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/99)
<!-- Reviewable:end -->

Closes https://github.com/HSLdevcom/jore4/issues/1003