### PR TITLE
Create framework for running Hasura repeatable migrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,8 @@
 # Deny everything.
 **
 
+# Except for
 !/LICENSE
-!/scripts/docker-entrypoint.sh
-!/scripts/replace-placeholders-in-sql-schema-migrations.sh
-!/scripts/merge-metadata.sh
-
+!/scripts/**
 !/metadata/**
 !/migrations/**

--- a/migrations/generic/default/1000000000000_R_before_migrate/down.sql
+++ b/migrations/generic/default/1000000000000_R_before_migrate/down.sql
@@ -1,0 +1,1 @@
+SELECT 'network database; before migrate hook; down migration';

--- a/migrations/generic/default/1000000000000_R_before_migrate/up.sql
+++ b/migrations/generic/default/1000000000000_R_before_migrate/up.sql
@@ -1,0 +1,2 @@
+-- This is a repeatable migration script that may be called multiple times
+SELECT 'network database; before migrate hook; up migration';

--- a/migrations/generic/default/2000000000000_R_after_migrate/down.sql
+++ b/migrations/generic/default/2000000000000_R_after_migrate/down.sql
@@ -1,0 +1,1 @@
+SELECT 'network database; after migrate hook; down migration';

--- a/migrations/generic/default/2000000000000_R_after_migrate/up.sql
+++ b/migrations/generic/default/2000000000000_R_after_migrate/up.sql
@@ -1,0 +1,2 @@
+-- This is a repeatable migration script that may be called multiple times
+SELECT 'network database; after migrate hook; up migration';

--- a/migrations/generic/timetables/1000000000000_R_before_migrate/down.sql
+++ b/migrations/generic/timetables/1000000000000_R_before_migrate/down.sql
@@ -1,0 +1,1 @@
+SELECT 'timetables database; before migrate hook; down migration';

--- a/migrations/generic/timetables/1000000000000_R_before_migrate/up.sql
+++ b/migrations/generic/timetables/1000000000000_R_before_migrate/up.sql
@@ -1,0 +1,2 @@
+-- This is a repeatable migration script that may be called multiple times
+SELECT 'timetables database; before migrate hook; up migration';

--- a/migrations/generic/timetables/2000000000000_R_after_migrate/down.sql
+++ b/migrations/generic/timetables/2000000000000_R_after_migrate/down.sql
@@ -1,0 +1,1 @@
+SELECT 'timetables database; after migrate hook; down migration';

--- a/migrations/generic/timetables/2000000000000_R_after_migrate/up.sql
+++ b/migrations/generic/timetables/2000000000000_R_after_migrate/up.sql
@@ -1,0 +1,2 @@
+-- This is a repeatable migration script that may be called multiple times
+SELECT 'timetables database; after migrate hook; up migration';

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -12,9 +12,11 @@ REPLACE_PLACEHOLDERS_SCRIPT='/app/scripts/replace-placeholders-in-sql-schema-mig
 # HASURA_GRAPHQL_MIGRATIONS_DIR is defined in the Dockerfile.
 "${REPLACE_PLACEHOLDERS_SCRIPT}" "${SECRET_STORE_BASE_PATH}" "${HASURA_GRAPHQL_MIGRATIONS_DIR}"
 
-# This script extends the functionality of the original Hasura docker image’s /bin/docker-entrypoint.sh script
-# HASURA_GRAPHQL_DATABASE_URL format: postgres://<user>:<password>@<host>:<port>/<db-name>
+# Tweak Hasura internal database to enable repeatable migrations
+/app/scripts/repeatable-migrations.sh
+
+# Pass on the execution to Hasura's own docker-entrypoint.sh file to (re)run the migrations
 HASURA_GRAPHQL_ADMIN_SECRET="$HASURA_ADMIN_SECRET" \
-  HASURA_GRAPHQL_DATABASE_URL="postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:5432/${DB_NAME}" \
-  HASURA_TIMETABLES_DATABASE_URL="postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:5432/${DB_TIMETABLES_NAME}" \
+  HASURA_GRAPHQL_DATABASE_URL="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:5432/${DB_NAME}" \
+  HASURA_TIMETABLES_DATABASE_URL="postgresql://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOSTNAME}:5432/${DB_TIMETABLES_NAME}" \
   exec /bin/docker-entrypoint.sh "$@"

--- a/scripts/repeatable-migrations.sh
+++ b/scripts/repeatable-migrations.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -eu
+
+# This script is used to enable repeatable migrations in Hasura. It does the following:
+# 1. checks if Hasura migrations have ever been run. If not, there's no need for any tweaks
+# 2. finds all the migrations that match the "<timestamp>_R_<migration name>" pattern
+# 3. removes these timestamp entries from Hasura's hdb_catalog.hdb_version table
+# When hasura is started, it thinks that these migrations have not been run yet so it runs them again
+# Note: we require repeatable migrations to be idempotent
+
+# psql base command
+PSQL_CMD="psql -h ${DB_HOSTNAME} -p 5432 -U ${DB_USERNAME} -d ${DB_NAME}"
+
+# check whether hasura hdb catalog already exists
+HDB_CATALOG_EXISTS_QUERY=$(cat << EOF
+SELECT EXISTS (
+  SELECT FROM pg_tables
+  WHERE schemaname = 'hdb_catalog'
+    AND tablename  = 'hdb_version'
+);
+EOF
+)
+HDB_CATALOG_EXISTS=`PGPASSWORD="${DB_PASSWORD}" ${PSQL_CMD} -t -c "${HDB_CATALOG_EXISTS_QUERY}"`
+echo "HDB_CATALOG_EXISTS: $HDB_CATALOG_EXISTS"
+
+# 1. hdb catalog does not exist (yet), no need to tweak migrations. Exit with success
+if [ $HDB_CATALOG_EXISTS != "t" ]; then
+  echo "hdb_catalog does not exist (yet), no need to tweak migrations"
+  exit 0;
+fi
+
+# 2. find the repeatable migrations ("timestamp_R_name") in migrations dir
+DATABASES=( "default" "timetables" )
+for DB in "${DATABASES[@]}"
+do
+  echo "Looking for repeatable migrations for database: $DB"
+
+  # use regex to find all matching migration names and grep to extract the timestamp part, then put it into an array
+  TIMESTAMPS=($(find "${HASURA_GRAPHQL_MIGRATIONS_DIR}" -type d -regex ".*/${DB}/[0-9]*_R_.*" | grep -oE "[0-9]{13}"))
+
+  echo "Found repeatable migrations: $TIMESTAMPS"
+
+  for TIMESTAMP in "${TIMESTAMPS[@]}"
+  do
+
+# build query to remove repeatable migrations' entries from hdb_catalog
+REMOVE_REPEATABLE_MIGRATIONS_QUERY=$(cat << EOF
+UPDATE hdb_catalog.hdb_version SET cli_state =
+  (cli_state
+  #- '{migrations,$DB,$TIMESTAMP}')
+EOF
+)
+
+    # run query
+    PGPASSWORD="${DB_PASSWORD}" ${PSQL_CMD} -c "${REMOVE_REPEATABLE_MIGRATIONS_QUERY}"
+  done
+done


### PR DESCRIPTION
We remove the migration records from Hasura's hdb_catalog.hdb_version table for some dedicated migrations. Thus when restarting the hasura container, these migrations will be rerun in the order of their timestamps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/111)
<!-- Reviewable:end -->
