### PR TITLE
Squash and split timetables sql migrations

### DIFF
--- a/migrations/generic/timetables/1000000000000_R_before_migrate/down.sql
+++ b/migrations/generic/timetables/1000000000000_R_before_migrate/down.sql
@@ -1,1 +1,7 @@
-SELECT 'timetables database; before migrate hook; down migration';
+DROP SCHEMA journey_pattern;
+DROP SCHEMA service_pattern;
+DROP SCHEMA service_calendar;
+DROP SCHEMA vehicle_schedule;
+DROP SCHEMA vehicle_service;
+DROP SCHEMA vehicle_journey;
+DROP SCHEMA passing_times;

--- a/migrations/generic/timetables/1000000000000_R_before_migrate/up.sql
+++ b/migrations/generic/timetables/1000000000000_R_before_migrate/up.sql
@@ -1,2 +1,138 @@
--- This is a repeatable migration script that may be called multiple times
-SELECT 'timetables database; before migrate hook; up migration';
+-- create schemas if they don't yet exist, because the drop function below reference them
+CREATE SCHEMA IF NOT EXISTS journey_pattern;
+COMMENT ON SCHEMA journey_pattern IS 'The journey pattern model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:683 ';
+CREATE SCHEMA IF NOT EXISTS service_pattern;
+COMMENT ON SCHEMA service_pattern IS 'The service pattern model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:4:723 ';
+CREATE SCHEMA IF NOT EXISTS service_calendar;
+COMMENT ON SCHEMA service_calendar IS 'The service calendar model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=1:6:3:294 ';
+CREATE SCHEMA IF NOT EXISTS vehicle_schedule;
+COMMENT ON SCHEMA vehicle_schedule IS 'The vehicle schedule frame adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:7:2:993 ';
+CREATE SCHEMA IF NOT EXISTS vehicle_service;
+COMMENT ON SCHEMA vehicle_service IS 'The vehicle service model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:5:947 ';
+CREATE SCHEMA IF NOT EXISTS vehicle_journey;
+COMMENT ON SCHEMA vehicle_journey IS 'The vehicle journey model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:1:1:824 ';
+CREATE SCHEMA IF NOT EXISTS passing_times;
+COMMENT ON SCHEMA passing_times IS 'The passing times model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:4:939 ';
+
+-- drop all triggers in jore4 schemas
+-- note: information_schema.triggers is missing TRUNCATE triggers
+-- note2: pg_catalog.pg_triggers contains the TRUNCATE triggers but many other things too
+-- so here we combine a bit of both
+DO $$
+DECLARE
+  trigger_record RECORD;
+BEGIN
+  FOR trigger_record IN
+    (
+      -- CRUD triggers
+      SELECT
+        trigger_schema AS schema_name,
+        event_object_table AS table_name,
+        trigger_name
+      FROM information_schema.triggers
+      WHERE
+        trigger_schema IN (
+          'journey_pattern',
+          'service_pattern',
+          'service_calendar',
+          'vehicle_schedule',
+          'vehicle_service',
+          'vehicle_journey',
+          'passing_times'
+    ) UNION (
+      -- TRUNCATE triggers
+      SELECT
+        n.nspname as schema_name,
+        c.relname as table_name,
+        t.tgname AS trigger_name
+      FROM pg_trigger t
+        JOIN pg_class c on t.tgrelid = c.oid
+        JOIN pg_namespace n on c.relnamespace = n.oid
+      WHERE
+        t.tgtype = 32 AND -- TRUNCATE triggers only
+        n.nspname IN (
+          'journey_pattern',
+          'service_pattern',
+          'service_calendar',
+          'vehicle_schedule',
+          'vehicle_service',
+          'vehicle_journey',
+          'passing_times'
+      )
+    ))
+  LOOP
+    -- note: if the same trigger function is executed e.g. both on INSERT and UPDATE, there are two rows with the same trigger name
+    -- This results in the DROP command being executed twice below, thus we use IF EXISTS here
+    RAISE NOTICE 'Dropping trigger: %.%.%', trigger_record.schema_name, trigger_record.table_name, trigger_record.trigger_name;
+    EXECUTE 'DROP TRIGGER IF EXISTS ' || quote_ident(trigger_record.trigger_name) || ' ON ' || quote_ident(trigger_record.schema_name) || '.' || quote_ident(trigger_record.table_name) || ';';
+  END LOOP;
+END;
+$$;
+
+-- dropping all constrains in jore4 schemas (except for primary and foreign key constraints)
+DO $$
+DECLARE
+  constraint_record RECORD;
+BEGIN
+  FOR constraint_record IN (
+    SELECT
+      n.nspname as schema_name,
+      t.relname as table_name,
+      c.conname as constraint_name
+    FROM pg_constraint c
+      JOIN pg_class t on c.conrelid = t.oid
+      JOIN pg_namespace n on t.relnamespace = n.oid
+    WHERE
+      -- c = check constraint, f = foreign key constraint, p = primary key constraint, u = unique constraint, t = constraint trigger, x = exclusion constraint
+      c.contype IN ('c', 'u', 't', 'x') AND
+      n.nspname IN (
+        'journey_pattern',
+        'service_pattern',
+        'service_calendar',
+        'vehicle_schedule',
+        'vehicle_service',
+        'vehicle_journey',
+        'passing_times'
+    ))
+  LOOP
+    RAISE NOTICE 'Dropping constraint: %.%.%', constraint_record.schema_name, constraint_record.table_name, constraint_record.constraint_name;
+    EXECUTE 'ALTER TABLE ' || quote_ident(constraint_record.schema_name) || '.' || quote_ident(constraint_record.table_name) || ' DROP CONSTRAINT ' || quote_ident(constraint_record.constraint_name) || ';';
+  END LOOP;
+END;
+$$;
+
+-- drop all functions in jore4 schemas
+DO $$
+DECLARE
+  sql_command text;
+BEGIN
+  SELECT INTO sql_command
+    string_agg(
+      format('DROP %s %s;',
+        CASE prokind
+          WHEN 'f' THEN 'FUNCTION'
+          WHEN 'a' THEN 'AGGREGATE'
+          WHEN 'p' THEN 'PROCEDURE'
+          WHEN 'w' THEN 'FUNCTION'
+          ELSE NULL
+        END,
+        oid::regprocedure),
+      E'\n')
+  FROM pg_proc
+  WHERE pronamespace IN (
+    'journey_pattern'::regnamespace,
+    'service_pattern'::regnamespace,
+    'service_calendar'::regnamespace,
+    'vehicle_schedule'::regnamespace,
+    'vehicle_service'::regnamespace,
+    'vehicle_journey'::regnamespace,
+    'passing_times'::regnamespace
+  );
+
+  IF sql_command IS NOT NULL THEN
+    EXECUTE sql_command;
+  ELSE
+    RAISE NOTICE 'No functions found';
+  END IF;
+END;
+$$;

--- a/migrations/generic/timetables/1663231564515_timetables_initial/down.sql
+++ b/migrations/generic/timetables/1663231564515_timetables_initial/down.sql
@@ -1,35 +1,28 @@
 -------------------- Passing Times --------------------
 
-DROP TABLE passing_times.timetabled_passing_time;
-DROP SCHEMA passing_times;
+DROP TABLE passing_times.timetabled_passing_time CASCADE;
 
 -------------------- Vehicle Journey --------------------
 
-DROP TABLE vehicle_journey.vehicle_journey;
-DROP SCHEMA vehicle_journey;
+DROP TABLE vehicle_journey.vehicle_journey CASCADE;
 
 -------------------- Vehicle Service --------------------
 
-DROP TABLE vehicle_service.block;
-DROP TABLE vehicle_service.vehicle_service;
-DROP SCHEMA vehicle_service;
+DROP TABLE vehicle_service.block CASCADE;
+DROP TABLE vehicle_service.vehicle_service CASCADE;
 
 -------------------- Vehicle Schedule --------------------
 
-DROP TABLE vehicle_schedule.vehicle_schedule_frame;
-DROP SCHEMA vehicle_schedule;
+DROP TABLE vehicle_schedule.vehicle_schedule_frame CASCADE;
 
 -------------------- Service Calendar --------------------
 
-DROP TABLE service_calendar.day_type;
-DROP SCHEMA service_calendar;
+DROP TABLE service_calendar.day_type CASCADE;
 
 -------------------- Service Pattern --------------------
 
-DROP TABLE service_pattern.scheduled_stop_point_in_journey_pattern_ref;
-DROP SCHEMA service_pattern;
+DROP TABLE service_pattern.scheduled_stop_point_in_journey_pattern_ref CASCADE;
 
 -------------------- Journey Pattern --------------------
 
-DROP TABLE journey_pattern.journey_pattern_ref;
-DROP SCHEMA journey_pattern;
+DROP TABLE journey_pattern.journey_pattern_ref CASCADE;

--- a/migrations/generic/timetables/1666961618554_day_types/up.sql
+++ b/migrations/generic/timetables/1666961618554_day_types/up.sql
@@ -1,6 +1,6 @@
 CREATE TABLE service_calendar.day_type_active_on_day_of_week (
   day_type_id uuid REFERENCES service_calendar.day_type (day_type_id) NOT NULL,
-  day_of_week int NOT NULL CHECK (day_of_week >= 1 AND day_of_week <= 7),
+  day_of_week int NOT NULL,
   PRIMARY KEY(day_type_id, day_of_week)
 );
 COMMENT ON TABLE service_calendar.day_type_active_on_day_of_week IS 'Tells on which days of week a particular DAY TYPE is active';

--- a/migrations/generic/timetables/1667215510823_add_vehicle_journey_computed_fields/down.sql
+++ b/migrations/generic/timetables/1667215510823_add_vehicle_journey_computed_fields/down.sql
@@ -1,2 +1,0 @@
-DROP FUNCTION vehicle_journey.vehicle_journey_start_time(vj vehicle_journey.vehicle_journey);
-DROP FUNCTION vehicle_journey.vehicle_journey_end_time(vj vehicle_journey.vehicle_journey);

--- a/migrations/generic/timetables/2000000000000_R_after_migrate_create_vehicle_journey/down.sql
+++ b/migrations/generic/timetables/2000000000000_R_after_migrate_create_vehicle_journey/down.sql
@@ -1,0 +1,2 @@
+-- we don't drop functions and constraints here, they are dropped in the before_migrate hook
+SELECT 1;

--- a/migrations/generic/timetables/2000000000000_R_after_migrate_create_vehicle_journey/up.sql
+++ b/migrations/generic/timetables/2000000000000_R_after_migrate_create_vehicle_journey/up.sql
@@ -2,14 +2,14 @@
 -- hasura won't let save those as computed fields:
 -- "Inconsistent object: in table "vehicle_journey.vehicle_journey": in computed field "start_time": the computed field "start_time" cannot be added to table "vehicle_journey.vehicle_journey" because the function "vehicle_journey.vehicle_journey_start_time" returning type interval is not a BASE type"
 
-CREATE FUNCTION vehicle_journey.vehicle_journey_start_time(vj vehicle_journey.vehicle_journey)
+CREATE OR REPLACE FUNCTION vehicle_journey.vehicle_journey_start_time(vj vehicle_journey.vehicle_journey)
 RETURNS text AS $$
   SELECT MIN (departure_time)::text AS start_time
   FROM passing_times.timetabled_passing_time tpt
   WHERE tpt.vehicle_journey_id = vj.vehicle_journey_id;
 $$ LANGUAGE sql STABLE;
 
-CREATE FUNCTION vehicle_journey.vehicle_journey_end_time(vj vehicle_journey.vehicle_journey)
+CREATE OR REPLACE FUNCTION vehicle_journey.vehicle_journey_end_time(vj vehicle_journey.vehicle_journey)
 RETURNS text AS $$
   SELECT MAX (arrival_time)::text AS end_time
   FROM passing_times.timetabled_passing_time tpt

--- a/migrations/generic/timetables/2000000000000_after_migrate/down.sql
+++ b/migrations/generic/timetables/2000000000000_after_migrate/down.sql
@@ -1,1 +1,0 @@
-SELECT 'timetables database; after migrate hook; down migration';

--- a/migrations/generic/timetables/2000000000000_after_migrate/up.sql
+++ b/migrations/generic/timetables/2000000000000_after_migrate/up.sql
@@ -1,2 +1,0 @@
--- This is a repeatable migration script that may be called multiple times
-SELECT 'timetables database; after migrate hook; up migration';

--- a/migrations/generic/timetables/2000000000001_R_after_migrate_create_passing_times/down.sql
+++ b/migrations/generic/timetables/2000000000001_R_after_migrate_create_passing_times/down.sql
@@ -1,0 +1,2 @@
+-- we don't drop functions and constraints here, they are dropped in the before_migrate hook
+SELECT 1;

--- a/migrations/generic/timetables/2000000000001_R_after_migrate_create_passing_times/up.sql
+++ b/migrations/generic/timetables/2000000000001_R_after_migrate_create_passing_times/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE passing_times.timetabled_passing_time
+  ADD CONSTRAINT arrival_or_departure_time_exists CHECK (arrival_time IS NOT NULL OR departure_time IS NOT NULL);

--- a/migrations/generic/timetables/2000000000002_R_after_migrate_create_service_calendar/down.sql
+++ b/migrations/generic/timetables/2000000000002_R_after_migrate_create_service_calendar/down.sql
@@ -1,0 +1,2 @@
+-- we don't drop functions and constraints here, they are dropped in the before_migrate hook
+SELECT 1;

--- a/migrations/generic/timetables/2000000000002_R_after_migrate_create_service_calendar/up.sql
+++ b/migrations/generic/timetables/2000000000002_R_after_migrate_create_service_calendar/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE service_calendar.day_type_active_on_day_of_week
+  ADD CONSTRAINT day_type_active_on_day_of_week_day_of_week_check CHECK (day_of_week >= 1 AND day_of_week <= 7);

--- a/migrations/timetablesdb-dump.sql
+++ b/migrations/timetablesdb-dump.sql
@@ -291,13 +291,6 @@ ALTER TABLE ONLY passing_times.timetabled_passing_time
     ADD CONSTRAINT timetabled_passing_time_pkey PRIMARY KEY (timetabled_passing_time_id);
 
 --
--- Name: day_type day_type_label_key; Type: CONSTRAINT; Schema: service_calendar; Owner: dbhasura
---
-
-ALTER TABLE ONLY service_calendar.day_type
-    ADD CONSTRAINT day_type_label_key UNIQUE (label);
-
---
 -- Name: day_type day_type_pkey; Type: CONSTRAINT; Schema: service_calendar; Owner: dbhasura
 --
 
@@ -310,13 +303,6 @@ ALTER TABLE ONLY service_calendar.day_type
 
 ALTER TABLE ONLY service_calendar.day_type_active_on_day_of_week
     ADD CONSTRAINT day_type_active_on_day_of_week_pkey PRIMARY KEY (day_type_id, day_of_week);
-
---
--- Name: scheduled_stop_point_in_journey_pattern_ref scheduled_stop_point_in_journ_journey_pattern_ref_id_schedu_key; Type: CONSTRAINT; Schema: service_pattern; Owner: dbhasura
---
-
-ALTER TABLE ONLY service_pattern.scheduled_stop_point_in_journey_pattern_ref
-    ADD CONSTRAINT scheduled_stop_point_in_journ_journey_pattern_ref_id_schedu_key UNIQUE (journey_pattern_ref_id, scheduled_stop_point_sequence);
 
 --
 -- Name: scheduled_stop_point_in_journey_pattern_ref scheduled_stop_point_in_journey_pattern_ref_pkey; Type: CONSTRAINT; Schema: service_pattern; Owner: dbhasura
@@ -463,6 +449,18 @@ $$;
 
 
 ALTER FUNCTION vehicle_journey.vehicle_journey_start_time(vj vehicle_journey.vehicle_journey) OWNER TO dbhasura;
+
+--
+-- Name: service_calendar_day_type_label_idx; Type: INDEX; Schema: service_calendar; Owner: dbhasura
+--
+
+CREATE UNIQUE INDEX service_calendar_day_type_label_idx ON service_calendar.day_type USING btree (label);
+
+--
+-- Name: service_pattern_scheduled_stop_point_in_journey_pattern_ref_idx; Type: INDEX; Schema: service_pattern; Owner: dbhasura
+--
+
+CREATE UNIQUE INDEX service_pattern_scheduled_stop_point_in_journey_pattern_ref_idx ON service_pattern.scheduled_stop_point_in_journey_pattern_ref USING btree (journey_pattern_ref_id, scheduled_stop_point_sequence);
 
 --
 -- Name: journey_pattern; Type: SCHEMA; Schema: -; Owner: dbhasura


### PR DESCRIPTION
Squashed and split database migrations:
- Added a before_migrate repeatable migration that drops all functions, constraints and triggers in jore4 schemas
- Squashed all data-related migrations into a few ones (create table, create index)
- Added after_migrate repeatable migrations to recreate all functions, constraints and triggers in jore4 schemas

The following other fixes were applied:
- changed unique table constraint into a unique index

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/114)
<!-- Reviewable:end -->

Build on top of PR #112 these two pull requests together refaktor all the sql migrations.
Closes https://github.com/HSLdevcom/jore4/issues/1014
