### PR TITLE
Update E2E docker-compose download script for private flux repo

### DIFF
--- a/scripts/start_dependencies.sh
+++ b/scripts/start_dependencies.sh
@@ -1,25 +1,29 @@
 #!/bin/bash
 
+# based on https://github.com/HSLdevcom/jore4-flux#docker-compose
+
 set -euo pipefail
 
 # allow running from any working directory
 WD=$(dirname "$0")
 cd "${WD}"
 
-# initialize package folder
-mkdir -p ../docker
-
-# compare versions
-GITHUB_VERSION=$(curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/RELEASE_VERSION.txt --silent)
-LOCAL_VERSION=$(cat ../docker/RELEASE_VERSION.txt || echo "unknown")
-
-# download latest version of the docker-compose package in case it has changed
-if [ "$GITHUB_VERSION" != "$LOCAL_VERSION" ]; then
-  echo "E2E docker-compose package is not up to date, downloading a new version."
-  curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/e2e-docker-compose.tar.gz --silent | tar -xzf - -C ../docker/
-else
-  echo "E2E docker-compose package is up to date, no need to download new version."
+if ! command -v gh; then
+  echo "Please install the github gh tool on your machine."
+  exit 1
 fi
+
+# initialize package folder
+mkdir -p ./docker/update
+
+echo "Downloading latest version of E2E docker-compose package..."
+gh auth status || gh auth login
+
+# gh cannot overwrite existing files, therefore first download into separate dir. This way we still have the old copy
+# in case the download fails
+rm -rf ./docker/update/*
+gh release download e2e-docker-compose --repo HSLdevcom/jore4-flux --dir ./docker/update
+cp -R ./docker/update/* ./docker
 
 # start up test database and hasura for migrations
 docker-compose -f ../docker/docker-compose.yml -f ../docker/docker-compose.custom.yml up --build "$@" jore4-testdb jore4-hasura jore4-auth


### PR DESCRIPTION
The github gh-tool is used to download flux-releases instead of a direct https-download.