### PR TITLE
Rename relative_distance_from_infrastructure_link

### DIFF
--- a/metadata/generic/databases/default/tables/service_pattern_scheduled_stop_point.yaml
+++ b/metadata/generic/databases/default/tables/service_pattern_scheduled_stop_point.yaml
@@ -42,8 +42,8 @@ computed_fields:
       function:
         schema: service_pattern
         name: scheduled_stop_point_closest_point_on_infrastructure_link
-  - name: relative_distance_from_infrastructure_link
+  - name: relative_distance_from_infrastructure_link_start
     definition:
       function:
         schema: service_pattern
-        name: scheduled_stop_point_relative_distance_from_infrastructure_link
+        name: ssp_relative_distance_from_infrastructure_link_start

--- a/migrations/generic/default/2000000000005_R_after_migrate_create_service_pattern_2/up.sql
+++ b/migrations/generic/default/2000000000005_R_after_migrate_create_service_pattern_2/up.sql
@@ -166,7 +166,7 @@ CREATE OR REPLACE FUNCTION service_pattern.scheduled_stop_point_closest_point_on
 $$;
 COMMENT ON FUNCTION service_pattern.scheduled_stop_point_closest_point_on_infrastructure_link IS 'The point on the infrastructure link closest to measured_location. A PostGIS PointZ geography in EPSG:4326.';
 
-CREATE OR REPLACE FUNCTION service_pattern.scheduled_stop_point_relative_distance_from_infrastructure_link(ssp service_pattern.scheduled_stop_point) RETURNS double precision
+CREATE OR REPLACE FUNCTION service_pattern.ssp_relative_distance_from_infrastructure_link_start(ssp service_pattern.scheduled_stop_point) RETURNS double precision
     LANGUAGE sql STABLE
     AS $$
   SELECT
@@ -174,7 +174,7 @@ CREATE OR REPLACE FUNCTION service_pattern.scheduled_stop_point_relative_distanc
   FROM infrastructure_network.infrastructure_link il
   WHERE ssp.located_on_infrastructure_link_id = il.infrastructure_link_id;
 $$;
-COMMENT ON FUNCTION service_pattern.scheduled_stop_point_relative_distance_from_infrastructure_link IS 'The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].';
+COMMENT ON FUNCTION service_pattern.ssp_relative_distance_from_infrastructure_link_start IS 'The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].';
 
 ALTER TABLE ONLY service_pattern.scheduled_stop_point
     ADD CONSTRAINT unique_validity_period EXCLUDE USING gist (label WITH =, priority WITH =, internal_utils.daterange_closed_upper(validity_start, validity_end) WITH &&) WHERE ((priority < internal_utils.const_priority_draft()));

--- a/migrations/routesdb-dump.sql
+++ b/migrations/routesdb-dump.sql
@@ -898,10 +898,10 @@ COMMENT ON FUNCTION service_pattern.get_scheduled_stop_points_with_new(replace_s
 COMMENT ON FUNCTION service_pattern.scheduled_stop_point_closest_point_on_infrastructure_link(ssp service_pattern.scheduled_stop_point) IS 'The point on the infrastructure link closest to measured_location. A PostGIS PointZ geography in EPSG:4326.';
 
 --
--- Name: FUNCTION scheduled_stop_point_relative_distance_from_infrastructure_link(ssp service_pattern.scheduled_stop_point); Type: COMMENT; Schema: service_pattern; Owner: dbhasura
+-- Name: FUNCTION ssp_relative_distance_from_infrastructure_link_start(ssp service_pattern.scheduled_stop_point); Type: COMMENT; Schema: service_pattern; Owner: dbhasura
 --
 
-COMMENT ON FUNCTION service_pattern.scheduled_stop_point_relative_distance_from_infrastructure_link(ssp service_pattern.scheduled_stop_point) IS 'The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].';
+COMMENT ON FUNCTION service_pattern.ssp_relative_distance_from_infrastructure_link_start(ssp service_pattern.scheduled_stop_point) IS 'The relative distance of the stop from the start of the linestring along the infrastructure link. Regardless of the specified direction, this value is the distance from the beginning of the linestring. The distance is normalized to the closed interval [0, 1].';
 
 --
 -- Name: TABLE scheduled_stop_point; Type: COMMENT; Schema: service_pattern; Owner: dbhasura
@@ -3148,10 +3148,10 @@ $$;
 ALTER FUNCTION service_pattern.scheduled_stop_point_closest_point_on_infrastructure_link(ssp service_pattern.scheduled_stop_point) OWNER TO dbhasura;
 
 --
--- Name: scheduled_stop_point_relative_distance_from_infrastructure_link(service_pattern.scheduled_stop_point); Type: FUNCTION; Schema: service_pattern; Owner: dbhasura
+-- Name: ssp_relative_distance_from_infrastructure_link_start(service_pattern.scheduled_stop_point); Type: FUNCTION; Schema: service_pattern; Owner: dbhasura
 --
 
-CREATE FUNCTION service_pattern.scheduled_stop_point_relative_distance_from_infrastructure_link(ssp service_pattern.scheduled_stop_point) RETURNS double precision
+CREATE FUNCTION service_pattern.ssp_relative_distance_from_infrastructure_link_start(ssp service_pattern.scheduled_stop_point) RETURNS double precision
     LANGUAGE sql STABLE
     AS $$
   SELECT
@@ -3161,7 +3161,7 @@ CREATE FUNCTION service_pattern.scheduled_stop_point_relative_distance_from_infr
 $$;
 
 
-ALTER FUNCTION service_pattern.scheduled_stop_point_relative_distance_from_infrastructure_link(ssp service_pattern.scheduled_stop_point) OWNER TO dbhasura;
+ALTER FUNCTION service_pattern.ssp_relative_distance_from_infrastructure_link_start(ssp service_pattern.scheduled_stop_point) OWNER TO dbhasura;
 
 --
 -- Name: hdb_cron_event_invocation_event_id; Type: INDEX; Schema: hdb_catalog; Owner: dbhasura


### PR DESCRIPTION
Resolves HSLdevcom/jore4#1032

scheduled_stop_point_relative_distance_from_infrastructure_link_start is too long for PostgreSQL function name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-hasura/129)
<!-- Reviewable:end -->
