### PR TITLE
Run integration tests for HSL data model

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -156,3 +156,34 @@ jobs:
       # Running the all migrations down and up to make sure that they all work as intended
       - name: Run migration tests for both network and timetables databases
         run: ./scripts/test-migrations.sh
+
+  run_integration_tests:
+    needs: push_to_registry
+    name: Run hasura integration tests
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        include:
+          - imagePrefix: 'generic-'
+            testCommand: 'yarn qa' # includes linter, prettier and ts:check as well
+          - imagePrefix: 'hsl-'
+            testCommand: 'yarn test-hsl' # only runs the tests
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Extract metadata to env variables
+        uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
+
+      - name: start e2e env
+        uses: HSLdevcom/jore4-flux/github-actions/setup-e2e-environment@setup-e2e-environment-v1
+        with:
+          hasura_version: '${{ env.IMAGE_NAME }}:${{ matrix.imagePrefix }}${{ env.COMMIT_ID }}'
+
+      - name: Run integration tests
+        run: |
+          cd test/hasura
+          yarn --frozen-lockfile
+          ${{ matrix.testCommand }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,26 +19,3 @@ jobs:
       - name: Run tests
         run: |
           ./test/docker-image/string-interpolation/test.sh
-
-  run_integration_tests:
-    name: Run hasura tests
-    runs-on: ubuntu-20.04
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up dependencies
-        run: |
-          ./scripts/start_dependencies.sh -d
-
-      - name: Verify that hasura is up and running
-        uses: HSLdevcom/jore4-tools/github-actions/healthcheck@healthcheck-v1
-        with:
-          command: 'curl --fail http://localhost:3201/healthz --output /dev/null --silent'
-
-      - name: Run tests (including linter, prettier, ts:check)
-        run: |
-          cd test/hasura
-          yarn --frozen-lockfile
-          yarn qa


### PR DESCRIPTION
Integration test running is moved to cd.yml as it uses the just-built docker images instead of the local environment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/139)
<!-- Reviewable:end -->
