### PR TITLE
Separate seed data and table schema

### DIFF
--- a/scripts/prettify.sh
+++ b/scripts/prettify.sh
@@ -2,4 +2,4 @@
 
 set -eu
 
-npx prettier --write .
+npx prettier@2.4.1 --write .

--- a/test/hasura/generic/datasets/defaultSetup/index.ts
+++ b/test/hasura/generic/datasets/defaultSetup/index.ts
@@ -1,14 +1,4 @@
-import {
-  infrastructureLinkAlongRouteProps,
-  infrastructureLinkProps,
-  lineProps,
-  routeProps,
-  scheduledStopPointInvariantProps,
-  scheduledStopPointProps,
-  timingPatternTimingPlaceProps,
-  vehicleModeOnScheduledStopPointProps,
-  vehicleSubmodeOnInfrastructureLinkProps,
-} from '@datasets-generic/types';
+import { GenericNetworkDbTables } from '@datasets-generic/schema';
 import {
   infrastructureLinks,
   vehicleSubmodeOnInfrastructureLink,
@@ -22,50 +12,42 @@ import {
 } from './scheduled-stop-points';
 import { timingPlaces } from './timing-places';
 
-export const defaultTableConfig: TableLikeConfig[] = [
-  {
-    name: 'infrastructure_network.infrastructure_link',
-    data: infrastructureLinks,
-    props: infrastructureLinkProps,
-  },
-  {
-    name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
-    data: vehicleSubmodeOnInfrastructureLink,
-    props: vehicleSubmodeOnInfrastructureLinkProps,
-  },
-  {
-    name: 'timing_pattern.timing_place',
-    data: timingPlaces,
-    props: timingPatternTimingPlaceProps,
-  },
-  {
-    name: 'service_pattern.scheduled_stop_point_invariant',
-    data: scheduledStopPointInvariants,
-    props: scheduledStopPointInvariantProps,
-  },
-  {
-    name: 'service_pattern.scheduled_stop_point',
-    data: scheduledStopPoints,
-    props: scheduledStopPointProps,
-  },
-  {
-    name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
-    data: vehicleModeOnScheduledStopPoint,
-    props: vehicleModeOnScheduledStopPointProps,
-  },
-  { name: 'route.line', data: lines, props: lineProps },
-  { name: 'route.route', data: routes, props: routeProps },
-  {
-    name: 'route.infrastructure_link_along_route',
-    data: infrastructureLinkAlongRoute,
-    props: infrastructureLinkAlongRouteProps,
-  },
-
-  // views
-  {
-    name: 'service_pattern.scheduled_stop_point',
-    props: scheduledStopPointProps,
-    isView: true,
-  },
-  { name: 'route.route', props: routeProps, isView: true },
-];
+export const defaultGenericNetworkDbData: TableData<GenericNetworkDbTables>[] =
+  [
+    {
+      name: 'infrastructure_network.infrastructure_link',
+      data: infrastructureLinks,
+    },
+    {
+      name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
+      data: vehicleSubmodeOnInfrastructureLink,
+    },
+    {
+      name: 'timing_pattern.timing_place',
+      data: timingPlaces,
+    },
+    {
+      name: 'service_pattern.scheduled_stop_point_invariant',
+      data: scheduledStopPointInvariants,
+    },
+    {
+      name: 'service_pattern.scheduled_stop_point',
+      data: scheduledStopPoints,
+    },
+    {
+      name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
+      data: vehicleModeOnScheduledStopPoint,
+    },
+    {
+      name: 'route.line',
+      data: lines,
+    },
+    {
+      name: 'route.route',
+      data: routes,
+    },
+    {
+      name: 'route.infrastructure_link_along_route',
+      data: infrastructureLinkAlongRoute,
+    },
+  ];

--- a/test/hasura/generic/datasets/prioritizedRouteVerification/index.ts
+++ b/test/hasura/generic/datasets/prioritizedRouteVerification/index.ts
@@ -4,19 +4,7 @@ import {
   scheduledStopPointInJourneyPattern,
   scheduledStopPointInJourneyPatternWithTempRoute,
 } from '@datasets-generic/prioritizedRouteVerification/journey-patterns';
-import {
-  infrastructureLinkAlongRouteProps,
-  infrastructureLinkProps,
-  journeyPatternProps,
-  lineProps,
-  routeProps,
-  scheduledStopPointInJourneyPatternProps,
-  scheduledStopPointInvariantProps,
-  scheduledStopPointProps,
-  timingPatternTimingPlaceProps,
-  vehicleModeOnScheduledStopPointProps,
-  vehicleSubmodeOnInfrastructureLinkProps,
-} from '@datasets-generic/types';
+import { GenericNetworkDbTables } from '@datasets-generic/schema';
 import {
   infrastructureLinks,
   vehicleSubmodeOnInfrastructureLink,
@@ -37,66 +25,56 @@ import {
 } from './scheduled-stop-points';
 import { timingPlaces } from './timing-places';
 
-export const prioritizedRouteVerificationTableConfig: TableLikeConfig[] = [
-  {
-    name: 'infrastructure_network.infrastructure_link',
-    data: infrastructureLinks,
-    props: infrastructureLinkProps,
-  },
-  {
-    name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
-    data: vehicleSubmodeOnInfrastructureLink,
-    props: vehicleSubmodeOnInfrastructureLinkProps,
-  },
-  {
-    name: 'timing_pattern.timing_place',
-    data: timingPlaces,
-    props: timingPatternTimingPlaceProps,
-  },
-  {
-    name: 'service_pattern.scheduled_stop_point_invariant',
-    data: scheduledStopPointInvariants,
-    props: scheduledStopPointInvariantProps,
-  },
-  {
-    name: 'service_pattern.scheduled_stop_point',
-    data: scheduledStopPoints,
-    props: scheduledStopPointProps,
-  },
-  {
-    name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
-    data: vehicleModeOnScheduledStopPoint,
-    props: vehicleModeOnScheduledStopPointProps,
-  },
-  { name: 'route.line', data: lines, props: lineProps },
-  { name: 'route.route', data: routes, props: routeProps },
-  {
-    name: 'route.infrastructure_link_along_route',
-    data: infrastructureLinkAlongRoute,
-    props: infrastructureLinkAlongRouteProps,
-  },
-  {
-    name: 'journey_pattern.journey_pattern',
-    data: journeyPatterns,
-    props: journeyPatternProps,
-  },
-  {
-    name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
-    data: scheduledStopPointInJourneyPattern,
-    props: scheduledStopPointInJourneyPatternProps,
-  },
+export const prioritizedRouteVerificationTableData: TableData<GenericNetworkDbTables>[] =
+  [
+    {
+      name: 'infrastructure_network.infrastructure_link',
+      data: infrastructureLinks,
+    },
+    {
+      name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
+      data: vehicleSubmodeOnInfrastructureLink,
+    },
+    {
+      name: 'timing_pattern.timing_place',
+      data: timingPlaces,
+    },
+    {
+      name: 'service_pattern.scheduled_stop_point_invariant',
+      data: scheduledStopPointInvariants,
+    },
+    {
+      name: 'service_pattern.scheduled_stop_point',
+      data: scheduledStopPoints,
+    },
+    {
+      name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
+      data: vehicleModeOnScheduledStopPoint,
+    },
+    {
+      name: 'route.line',
+      data: lines,
+    },
+    {
+      name: 'route.route',
+      data: routes,
+    },
+    {
+      name: 'route.infrastructure_link_along_route',
+      data: infrastructureLinkAlongRoute,
+    },
+    {
+      name: 'journey_pattern.journey_pattern',
+      data: journeyPatterns,
+    },
+    {
+      name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
+      data: scheduledStopPointInJourneyPattern,
+    },
+  ];
 
-  // views
-  {
-    name: 'service_pattern.scheduled_stop_point',
-    props: scheduledStopPointProps,
-    isView: true,
-  },
-  { name: 'route.route', props: routeProps, isView: true },
-];
-
-export const prioritizedRouteVerificationWithTempRouteTableConfig: TableLikeConfig[] =
-  prioritizedRouteVerificationTableConfig.map((tableLikeConfig) => {
+export const prioritizedRouteVerificationWithTempRouteTableData: TableData<GenericNetworkDbTables>[] =
+  prioritizedRouteVerificationTableData.map((tableLikeConfig) => {
     if (!tableLikeConfig.data) {
       return tableLikeConfig; // no data defined
     }

--- a/test/hasura/generic/datasets/route116/index.ts
+++ b/test/hasura/generic/datasets/route116/index.ts
@@ -1,16 +1,4 @@
-import {
-  infrastructureLinkAlongRouteProps,
-  infrastructureLinkProps,
-  journeyPatternProps,
-  lineProps,
-  routeProps,
-  scheduledStopPointInJourneyPatternProps,
-  scheduledStopPointInvariantProps,
-  scheduledStopPointProps,
-  timingPatternTimingPlaceProps,
-  vehicleModeOnScheduledStopPointProps,
-  vehicleSubmodeOnInfrastructureLinkProps,
-} from '@datasets-generic/types';
+import { GenericNetworkDbTables } from '@datasets-generic/schema';
 import {
   journeyPatterns,
   scheduledStopPointInJourneyPattern,
@@ -24,60 +12,49 @@ import {
 } from './scheduled-stop-points';
 import { timingPlaces } from './timing-places';
 
-export const route116TableConfig: TableLikeConfig[] = [
+export const route116TableConfig: TableData<GenericNetworkDbTables>[] = [
   {
     name: 'infrastructure_network.infrastructure_link',
     data: 'generic/datasets/route116/infrastructure-links.sql',
-    props: infrastructureLinkProps,
   },
   {
     name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
     data: 'generic/datasets/route116/vehicle-submode-on-infrastructure-links.sql',
-    props: vehicleSubmodeOnInfrastructureLinkProps,
   },
   {
     name: 'timing_pattern.timing_place',
     data: timingPlaces,
-    props: timingPatternTimingPlaceProps,
   },
   {
     name: 'service_pattern.scheduled_stop_point_invariant',
     data: scheduledStopPointInvariants,
-    props: scheduledStopPointInvariantProps,
   },
   {
     name: 'service_pattern.scheduled_stop_point',
     data: scheduledStopPoints,
-    props: scheduledStopPointProps,
   },
   {
     name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
     data: vehicleModeOnScheduledStopPoint,
-    props: vehicleModeOnScheduledStopPointProps,
   },
-  { name: 'route.line', data: lines, props: lineProps },
-  { name: 'route.route', data: routes, props: routeProps },
+  {
+    name: 'route.line',
+    data: lines,
+  },
+  {
+    name: 'route.route',
+    data: routes,
+  },
   {
     name: 'route.infrastructure_link_along_route',
     data: infrastructureLinkAlongRoute,
-    props: infrastructureLinkAlongRouteProps,
   },
   {
     name: 'journey_pattern.journey_pattern',
     data: journeyPatterns,
-    props: journeyPatternProps,
   },
   {
     name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
     data: scheduledStopPointInJourneyPattern,
-    props: scheduledStopPointInJourneyPatternProps,
   },
-
-  // views
-  {
-    name: 'service_pattern.scheduled_stop_point',
-    props: scheduledStopPointProps,
-    isView: true,
-  },
-  { name: 'route.route', props: routeProps, isView: true },
 ];

--- a/test/hasura/generic/datasets/routesAndJourneyPatterns/index.ts
+++ b/test/hasura/generic/datasets/routesAndJourneyPatterns/index.ts
@@ -1,16 +1,4 @@
-import {
-  infrastructureLinkAlongRouteProps,
-  infrastructureLinkProps,
-  journeyPatternProps,
-  lineProps,
-  routeProps,
-  scheduledStopPointInJourneyPatternProps,
-  scheduledStopPointInvariantProps,
-  scheduledStopPointProps,
-  timingPatternTimingPlaceProps,
-  vehicleModeOnScheduledStopPointProps,
-  vehicleSubmodeOnInfrastructureLinkProps,
-} from '@datasets-generic/types';
+import { GenericNetworkDbTables } from '@datasets-generic/schema';
 import {
   infrastructureLinks,
   vehicleSubmodeOnInfrastructureLink,
@@ -28,52 +16,50 @@ import {
 } from './scheduled-stop-points';
 import { timingPlaces } from './timing-places';
 
-export const routesAndJourneyPatternsTableConfig: TableLikeConfig[] = [
-  {
-    name: 'infrastructure_network.infrastructure_link',
-    data: infrastructureLinks,
-    props: infrastructureLinkProps,
-  },
-  {
-    name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
-    data: vehicleSubmodeOnInfrastructureLink,
-    props: vehicleSubmodeOnInfrastructureLinkProps,
-  },
-  {
-    name: 'timing_pattern.timing_place',
-    data: timingPlaces,
-    props: timingPatternTimingPlaceProps,
-  },
-  {
-    name: 'service_pattern.scheduled_stop_point_invariant',
-    data: scheduledStopPointInvariants,
-    props: scheduledStopPointInvariantProps,
-  },
-  {
-    name: 'service_pattern.scheduled_stop_point',
-    data: scheduledStopPoints,
-    props: scheduledStopPointProps,
-  },
-  {
-    name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
-    data: vehicleModeOnScheduledStopPoint,
-    props: vehicleModeOnScheduledStopPointProps,
-  },
-  { name: 'route.line', data: lines, props: lineProps },
-  { name: 'route.route', data: routes, props: routeProps },
-  {
-    name: 'route.infrastructure_link_along_route',
-    data: infrastructureLinkAlongRoute,
-    props: infrastructureLinkAlongRouteProps,
-  },
-  {
-    name: 'journey_pattern.journey_pattern',
-    data: journeyPatterns,
-    props: journeyPatternProps,
-  },
-  {
-    name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
-    data: scheduledStopPointInJourneyPattern,
-    props: scheduledStopPointInJourneyPatternProps,
-  },
-];
+export const routesAndJourneyPatternsTableData: TableData<GenericNetworkDbTables>[] =
+  [
+    {
+      name: 'infrastructure_network.infrastructure_link',
+      data: infrastructureLinks,
+    },
+    {
+      name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
+      data: vehicleSubmodeOnInfrastructureLink,
+    },
+    {
+      name: 'timing_pattern.timing_place',
+      data: timingPlaces,
+    },
+    {
+      name: 'service_pattern.scheduled_stop_point_invariant',
+      data: scheduledStopPointInvariants,
+    },
+    {
+      name: 'service_pattern.scheduled_stop_point',
+      data: scheduledStopPoints,
+    },
+    {
+      name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
+      data: vehicleModeOnScheduledStopPoint,
+    },
+    {
+      name: 'route.line',
+      data: lines,
+    },
+    {
+      name: 'route.route',
+      data: routes,
+    },
+    {
+      name: 'route.infrastructure_link_along_route',
+      data: infrastructureLinkAlongRoute,
+    },
+    {
+      name: 'journey_pattern.journey_pattern',
+      data: journeyPatterns,
+    },
+    {
+      name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
+      data: scheduledStopPointInJourneyPattern,
+    },
+  ];

--- a/test/hasura/generic/datasets/schema.ts
+++ b/test/hasura/generic/datasets/schema.ts
@@ -1,0 +1,75 @@
+import {
+  infrastructureLinkAlongRouteProps,
+  infrastructureLinkProps,
+  journeyPatternProps,
+  lineProps,
+  routeProps,
+  scheduledStopPointInJourneyPatternProps,
+  scheduledStopPointInvariantProps,
+  scheduledStopPointProps,
+  timingPatternTimingPlaceProps,
+  vehicleModeOnScheduledStopPointProps,
+  vehicleSubmodeOnInfrastructureLinkProps,
+} from '@datasets-generic/types';
+
+export const genericNetworkDbTables = [
+  'infrastructure_network.infrastructure_link',
+  'infrastructure_network.vehicle_submode_on_infrastructure_link',
+  'timing_pattern.timing_place',
+  'service_pattern.scheduled_stop_point_invariant',
+  'service_pattern.scheduled_stop_point',
+  'service_pattern.vehicle_mode_on_scheduled_stop_point',
+  'route.line',
+  'route.route',
+  'route.infrastructure_link_along_route',
+  'journey_pattern.journey_pattern',
+  'journey_pattern.scheduled_stop_point_in_journey_pattern',
+] as const;
+export type GenericNetworkDbTables = typeof genericNetworkDbTables[number];
+
+export const genericNetworkDbSchema: TableSchemaMap<GenericNetworkDbTables> = {
+  'infrastructure_network.infrastructure_link': {
+    name: 'infrastructure_network.infrastructure_link',
+    props: infrastructureLinkProps,
+  },
+  'infrastructure_network.vehicle_submode_on_infrastructure_link': {
+    name: 'infrastructure_network.vehicle_submode_on_infrastructure_link',
+    props: vehicleSubmodeOnInfrastructureLinkProps,
+  },
+  'timing_pattern.timing_place': {
+    name: 'timing_pattern.timing_place',
+    props: timingPatternTimingPlaceProps,
+  },
+  'service_pattern.scheduled_stop_point_invariant': {
+    name: 'service_pattern.scheduled_stop_point_invariant',
+    props: scheduledStopPointInvariantProps,
+  },
+  'service_pattern.scheduled_stop_point': {
+    name: 'service_pattern.scheduled_stop_point',
+    props: scheduledStopPointProps,
+  },
+  'service_pattern.vehicle_mode_on_scheduled_stop_point': {
+    name: 'service_pattern.vehicle_mode_on_scheduled_stop_point',
+    props: vehicleModeOnScheduledStopPointProps,
+  },
+  'route.line': {
+    name: 'route.line',
+    props: lineProps,
+  },
+  'route.route': {
+    name: 'route.route',
+    props: routeProps,
+  },
+  'route.infrastructure_link_along_route': {
+    name: 'route.infrastructure_link_along_route',
+    props: infrastructureLinkAlongRouteProps,
+  },
+  'journey_pattern.journey_pattern': {
+    name: 'journey_pattern.journey_pattern',
+    props: journeyPatternProps,
+  },
+  'journey_pattern.scheduled_stop_point_in_journey_pattern': {
+    name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
+    props: scheduledStopPointInJourneyPatternProps,
+  },
+};

--- a/test/hasura/generic/integration-tests/data-integrity/line-routes/priority/insert-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/line-routes/priority/insert-route.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
 import { buildRoute } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, RouteDirection, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -46,7 +47,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (
     onLineId: string | undefined,
@@ -76,7 +77,10 @@ describe('Insert route', () => {
         body: { query: buildMutation(onLineId, priority) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length);
       expect(response.rows).toEqual(expect.arrayContaining(routes));
@@ -125,7 +129,10 @@ describe('Insert route', () => {
         body: { query: buildMutation(onLineId, priority) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length + 1);
 

--- a/test/hasura/generic/integration-tests/data-integrity/line-routes/priority/update-line.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/line-routes/priority/update-line.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Line, lineProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -42,7 +43,7 @@ describe('Update line', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (toBeUpdated: Partial<Line>) =>
     it('should return error response', async () => {
@@ -61,7 +62,10 @@ describe('Update line', () => {
         body: { query: buildMutation(toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.line');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.line'],
+      );
 
       expect(response.rowCount).toEqual(lines.length);
       expect(response.rows).toEqual(expect.arrayContaining(lines));
@@ -94,7 +98,10 @@ describe('Update line', () => {
         body: { query: buildMutation(toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.line');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.line'],
+      );
 
       const updated = completeUpdated(toBeUpdated);
 

--- a/test/hasura/generic/integration-tests/data-integrity/line-routes/priority/update-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/line-routes/priority/update-route.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -43,7 +44,7 @@ describe('Update route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (
     toBeUpdated: PartialRouteWithNullableOnLineID,
@@ -71,7 +72,10 @@ describe('Update route', () => {
         body: { query: buildMutation(toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length);
       expect(response.rows).toEqual(expect.arrayContaining(routes));
@@ -108,7 +112,10 @@ describe('Update route', () => {
         body: { query: buildMutation(toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       const updated = completeUpdated(toBeUpdated);
 

--- a/test/hasura/generic/integration-tests/data-integrity/line-routes/validity-period/insert-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/line-routes/validity-period/insert-route.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
 import { buildRoute } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, RouteDirection, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -51,7 +52,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (
     onLineId: string,
@@ -86,7 +87,10 @@ describe('Insert route', () => {
         },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length);
       expect(response.rows).toEqual(expect.arrayContaining(routes));
@@ -141,7 +145,10 @@ describe('Insert route', () => {
         },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length + 1);
 

--- a/test/hasura/generic/integration-tests/data-integrity/line-routes/validity-period/update-line.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/line-routes/validity-period/update-line.spec.ts
@@ -1,6 +1,7 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Line, lineProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -42,7 +43,7 @@ describe('Update line', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (line: Line, toBeUpdated: Partial<Line>) =>
     it('should return error response', async () => {
@@ -65,7 +66,10 @@ describe('Update line', () => {
         body: { query: buildMutation(line, toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.line');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.line'],
+      );
 
       expect(response.rowCount).toEqual(lines.length);
       expect(response.rows).toEqual(expect.arrayContaining(lines));
@@ -104,7 +108,10 @@ describe('Update line', () => {
         body: { query: buildMutation(line, toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.line');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.line'],
+      );
 
       const updated = completeUpdated(line, toBeUpdated);
 

--- a/test/hasura/generic/integration-tests/data-integrity/line-routes/validity-period/update-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/line-routes/validity-period/update-route.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -41,7 +42,7 @@ describe('Update route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (
     route: Route,
@@ -67,7 +68,10 @@ describe('Update route', () => {
         body: { query: buildMutation(route, toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length);
       expect(response.rows).toEqual(expect.arrayContaining(routes));
@@ -108,7 +112,10 @@ describe('Update route', () => {
         body: { query: buildMutation(route, toBeUpdated) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       const updated = completeUpdated(route, toBeUpdated);
 

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/check-inserting-stop-point-with-label-in-use-in-journey-pattern.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/check-inserting-stop-point-with-label-in-use-in-journey-pattern.spec.ts
@@ -11,6 +11,7 @@ import {
   scheduledStopPointWithSameLabelOnPrevLink,
   scheduledStopPointWithSameLabelOnSameLinkAfterNextStop,
 } from '@datasets-generic/route116/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   CheckInfraLinkStopRefsWithNewScheduledStopPointArgs,
   journeyPatternProps,
@@ -69,8 +70,7 @@ describe('Checking inserting a stop point with a label in use in a journey patte
 
       const stopResponse = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        route116TableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(stopResponse.rowCount).toEqual(scheduledStopPoints.length);

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/delete-infra-link-from-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/delete-infra-link-from-route.spec.ts
@@ -1,6 +1,7 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData } from '@datasets-generic/routesAndJourneyPatterns';
 import { infrastructureLinkAlongRoute } from '@datasets-generic/routesAndJourneyPatterns/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   InfrastructureLinkAlongRoute,
   infrastructureLinkAlongRouteProps,
@@ -35,7 +36,7 @@ describe('Delete infra link from route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   const postHasuraRequest = (toBeRemoved: InfrastructureLinkAlongRoute) =>
     rp.post({
@@ -64,8 +65,7 @@ describe('Delete infra link from route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.infrastructure_link_along_route',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['route.infrastructure_link_along_route'],
       );
 
       expect(response.rowCount).toEqual(infrastructureLinkAlongRoute.length);
@@ -97,8 +97,7 @@ describe('Delete infra link from route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.infrastructure_link_along_route',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['route.infrastructure_link_along_route'],
       );
 
       expect(response.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/delete-route-with-links-and-journey-pattern.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/delete-route-with-links-and-journey-pattern.spec.ts
@@ -1,6 +1,7 @@
 import * as config from '@config';
 import { route116TableConfig } from '@datasets-generic/route116';
 import { routes } from '@datasets-generic/route116/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -58,7 +59,10 @@ describe('Delete route with infra links and journey pattern', () => {
       body: { query: mutation },
     });
 
-    const response = await queryTable(dbConnection, 'route.route');
+    const response = await queryTable(
+      dbConnection,
+      genericNetworkDbSchema['route.route'],
+    );
 
     expect(response.rowCount).toEqual(routes.length - 1);
 

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/insert-complicated-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/insert-complicated-route.spec.ts
@@ -8,6 +8,7 @@ import {
   infrastructureLinkAlongRoute,
   routes,
 } from '@datasets-generic/route116/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
 import { queryTable, setupDb } from '@util/setup';
@@ -26,8 +27,7 @@ describe('Inserting a complicated route', () => {
   it('should create the route correctly in the database', async () => {
     const routeResponse = await queryTable(
       dbConnection,
-      'route.route',
-      route116TableConfig,
+      genericNetworkDbSchema['route.route'],
     );
 
     expect(routeResponse.rowCount).toEqual(routes.length);
@@ -35,8 +35,7 @@ describe('Inserting a complicated route', () => {
 
     const infrastructureLinkAlongRouteResponse = await queryTable(
       dbConnection,
-      'route.infrastructure_link_along_route',
-      route116TableConfig,
+      genericNetworkDbSchema['route.infrastructure_link_along_route'],
     );
 
     expect(infrastructureLinkAlongRouteResponse.rowCount).toEqual(
@@ -50,8 +49,7 @@ describe('Inserting a complicated route', () => {
   it('should create the journey pattern correctly in the database', async () => {
     const journeyPatternResponse = await queryTable(
       dbConnection,
-      'journey_pattern.journey_pattern',
-      route116TableConfig,
+      genericNetworkDbSchema['journey_pattern.journey_pattern'],
     );
 
     expect(journeyPatternResponse.rowCount).toEqual(journeyPatterns.length);
@@ -61,8 +59,9 @@ describe('Inserting a complicated route', () => {
 
     const scheduledStopPointInJourneyPatternResponse = await queryTable(
       dbConnection,
-      'journey_pattern.scheduled_stop_point_in_journey_pattern',
-      route116TableConfig,
+      genericNetworkDbSchema[
+        'journey_pattern.scheduled_stop_point_in_journey_pattern'
+      ],
     );
 
     expect(scheduledStopPointInJourneyPatternResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/insert-stop-into-journey-pattern.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/insert-stop-into-journey-pattern.spec.ts
@@ -1,10 +1,11 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData } from '@datasets-generic/routesAndJourneyPatterns';
 import {
   journeyPatterns,
   scheduledStopPointInJourneyPattern,
 } from '@datasets-generic/routesAndJourneyPatterns/journey-patterns';
 import { scheduledStopPoints } from '@datasets-generic/routesAndJourneyPatterns/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   ScheduledStopPointInJourneyPattern,
   scheduledStopPointInJourneyPatternProps,
@@ -54,7 +55,7 @@ describe('Insert scheduled stop point into journey pattern', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   const shouldReturnErrorResponse = (
     toBeInserted: ScheduledStopPointInJourneyPattern,
@@ -80,8 +81,9 @@ describe('Insert scheduled stop point into journey pattern', () => {
 
       const response = await queryTable(
         dbConnection,
-        'journey_pattern.scheduled_stop_point_in_journey_pattern',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema[
+          'journey_pattern.scheduled_stop_point_in_journey_pattern'
+        ],
       );
 
       expect(response.rowCount).toEqual(
@@ -123,8 +125,9 @@ describe('Insert scheduled stop point into journey pattern', () => {
 
       const response = await queryTable(
         dbConnection,
-        'journey_pattern.scheduled_stop_point_in_journey_pattern',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema[
+          'journey_pattern.scheduled_stop_point_in_journey_pattern'
+        ],
       );
 
       expect(response.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/insert-stop-point-with-label-in-use-in-journey-pattern.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/insert-stop-point-with-label-in-use-in-journey-pattern.spec.ts
@@ -10,6 +10,7 @@ import {
   scheduledStopPointWithSameLabelOnPrevLink,
   scheduledStopPointWithSameLabelOnSameLinkAfterNextStop,
 } from '@datasets-generic/route116/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   ScheduledStopPoint,
   scheduledStopPointProps,
@@ -81,8 +82,7 @@ describe('Inserting a stop point with a label in use in a journey pattern', () =
 
       const stopResponse = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        route116TableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(stopResponse.rowCount).toEqual(scheduledStopPoints.length);
@@ -133,7 +133,7 @@ describe('Inserting a stop point with a label in use in a journey pattern', () =
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/create-temp-route-with-different-infra-links.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/create-temp-route-with-different-infra-links.spec.ts
@@ -1,5 +1,5 @@
 import * as config from '@config';
-import { prioritizedRouteVerificationTableConfig } from '@datasets-generic/prioritizedRouteVerification';
+import { prioritizedRouteVerificationTableData } from '@datasets-generic/prioritizedRouteVerification';
 import {
   scheduledStopPointInTempJourneyPatternWithoutConflictingInfraLinkStop,
   scheduledStopPointInTempJourneyPatternWithSameStops,
@@ -35,7 +35,7 @@ describe('Creating a temporary route with different infra links', () => {
   afterAll(() => closeDbConnection(dbConnection));
 
   beforeEach(() =>
-    setupDb(dbConnection, prioritizedRouteVerificationTableConfig),
+    setupDb(dbConnection, prioritizedRouteVerificationTableData),
   );
 
   it('should fail when inserting the conflicting stop first', async () => {

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/create-temp-route-with-different-stop-order.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/create-temp-route-with-different-stop-order.spec.ts
@@ -1,5 +1,5 @@
 import * as config from '@config';
-import { prioritizedRouteVerificationTableConfig } from '@datasets-generic/prioritizedRouteVerification';
+import { prioritizedRouteVerificationTableData } from '@datasets-generic/prioritizedRouteVerification';
 import { scheduledStopPointInTempJourneyPatternWithoutConflictingOrderStop } from '@datasets-generic/prioritizedRouteVerification/journey-patterns';
 import {
   infrastructureLinkAlongTempRouteWithSameLinks,
@@ -30,7 +30,7 @@ describe('Creating a temporary route with different stop order', () => {
   afterAll(() => closeDbConnection(dbConnection));
 
   beforeEach(() =>
-    setupDb(dbConnection, prioritizedRouteVerificationTableConfig),
+    setupDb(dbConnection, prioritizedRouteVerificationTableData),
   );
 
   it('should fail when inserting the conflicting stop first', async () => {

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/insert-stop-point-instance-after-temp-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/insert-stop-point-instance-after-temp-route.spec.ts
@@ -1,10 +1,11 @@
 import * as config from '@config';
-import { prioritizedRouteVerificationWithTempRouteTableConfig } from '@datasets-generic/prioritizedRouteVerification';
+import { prioritizedRouteVerificationWithTempRouteTableData } from '@datasets-generic/prioritizedRouteVerification';
 import {
   scheduledStopPointsWithTempRoute,
   tempScheduledStopPointWithConflictingInfraLinkOrderValidAfterTempRoute,
   tempScheduledStopPointWithNonConflictingInfraLinkOrderValidAfterTempRoute,
 } from '@datasets-generic/prioritizedRouteVerification/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { serializeMatcherInput, serializeMatcherInputs } from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
@@ -25,7 +26,7 @@ describe('Insert scheduled stop point after temp route', () => {
   afterAll(() => closeDbConnection(dbConnection));
 
   beforeEach(() =>
-    setupDb(dbConnection, prioritizedRouteVerificationWithTempRouteTableConfig),
+    setupDb(dbConnection, prioritizedRouteVerificationWithTempRouteTableData),
   );
 
   describe("when stop order is conflicting with basic route's other validity span's stop order", () => {
@@ -42,8 +43,7 @@ describe('Insert scheduled stop point after temp route', () => {
 
       const stopResponse = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        prioritizedRouteVerificationWithTempRouteTableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(stopResponse.rowCount).toEqual(
@@ -76,8 +76,7 @@ describe('Insert scheduled stop point after temp route', () => {
 
       const stopResponse = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        prioritizedRouteVerificationWithTempRouteTableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(stopResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/remove-temp-instance.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/remove-temp-instance.spec.ts
@@ -1,5 +1,5 @@
 import * as config from '@config';
-import { prioritizedRouteVerificationTableConfig } from '@datasets-generic/prioritizedRouteVerification';
+import { prioritizedRouteVerificationTableData } from '@datasets-generic/prioritizedRouteVerification';
 import {
   scheduledStopPointInTempJourneyPatternWithoutConflictingInfraLinkStop,
   scheduledStopPointInTempJourneyPatternWithSameStops,
@@ -35,7 +35,7 @@ describe('Removing a temporary...', () => {
   afterAll(() => closeDbConnection(dbConnection));
 
   beforeEach(() =>
-    setupDb(dbConnection, prioritizedRouteVerificationTableConfig),
+    setupDb(dbConnection, prioritizedRouteVerificationTableData),
   );
 
   it('...route should fail if the underlying basic route is in conflict with the stop points', async () => {

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/util.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/prioritized-route-verification/util.ts
@@ -1,6 +1,6 @@
 import * as config from '@config';
-import { prioritizedRouteVerificationTableConfig } from '@datasets-generic/prioritizedRouteVerification';
 import { scheduledStopPoints } from '@datasets-generic/prioritizedRouteVerification/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   CheckInfraLinkStopRefsWithNewScheduledStopPointArgs,
   InfrastructureLinkAlongRoute,
@@ -227,8 +227,7 @@ export const shouldNotModifyScheduledStopPointsInDatabase = async (
 ) => {
   const stopResponse = await queryTable(
     dbConnection,
-    'service_pattern.scheduled_stop_point',
-    prioritizedRouteVerificationTableConfig,
+    genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
   );
 
   expect(stopResponse.rowCount).toEqual(scheduledStopPoints.length);
@@ -263,7 +262,7 @@ export const shouldInsertScheduledStopPointCorrectlyIntoDatabase = async (
 ) => {
   const response = await queryTable(
     dbConnection,
-    'service_pattern.scheduled_stop_point',
+    genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
   );
 
   expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-infra-link-in-route.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-infra-link-in-route.spec.ts
@@ -1,9 +1,10 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData } from '@datasets-generic/routesAndJourneyPatterns';
 import {
   infrastructureLinkAlongRoute,
   routes,
 } from '@datasets-generic/routesAndJourneyPatterns/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   InfrastructureLinkAlongRoute,
   infrastructureLinkAlongRouteProps,
@@ -45,7 +46,7 @@ describe('Move infra link to other route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   describe('when there is a stop on the link', () => {
     const toBeMoved = infrastructureLinkAlongRoute[0];
@@ -87,8 +88,7 @@ describe('Move infra link to other route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.infrastructure_link_along_route',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['route.infrastructure_link_along_route'],
       );
 
       expect(response.rowCount).toEqual(infrastructureLinkAlongRoute.length);
@@ -146,8 +146,7 @@ describe('Move infra link to other route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.infrastructure_link_along_route',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['route.infrastructure_link_along_route'],
       );
 
       expect(response.rowCount).toEqual(infrastructureLinkAlongRoute.length);

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-journey-pattern.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-journey-pattern.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData } from '@datasets-generic/routesAndJourneyPatterns';
 import { journeyPatterns } from '@datasets-generic/routesAndJourneyPatterns/journey-patterns';
 import { routes } from '@datasets-generic/routesAndJourneyPatterns/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { journeyPatternProps } from '@datasets-generic/types';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
@@ -34,7 +35,7 @@ describe('Move journey pattern to other route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   const shouldReturnErrorMessage = (
     journeyPatternId: string,
@@ -66,8 +67,7 @@ describe('Move journey pattern to other route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'journey_pattern.journey_pattern',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['journey_pattern.journey_pattern'],
       );
 
       expect(response.rowCount).toEqual(journeyPatterns.length);
@@ -137,8 +137,7 @@ describe('Move journey pattern to other route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'journey_pattern.journey_pattern',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['journey_pattern.journey_pattern'],
       );
 
       expect(response.rowCount).toEqual(journeyPatterns.length);

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-scheduled-stop-point.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-scheduled-stop-point.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData } from '@datasets-generic/routesAndJourneyPatterns';
 import { infrastructureLinks } from '@datasets-generic/routesAndJourneyPatterns/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/routesAndJourneyPatterns/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { scheduledStopPointProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { serializeMatcherInputs } from '@util/dataset';
@@ -58,7 +59,7 @@ describe('Move scheduled stop point to other infra link', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   const shouldReturnErrorResponse = (
     scheduledStopPointId: string,
@@ -96,8 +97,7 @@ describe('Move scheduled stop point to other infra link', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);
@@ -188,8 +188,7 @@ describe('Move scheduled stop point to other infra link', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);
@@ -218,7 +217,7 @@ describe('Change scheduled stop point timing place', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   const shouldReturnErrorResponse = (
     scheduledStopPointId: string,
@@ -256,8 +255,7 @@ describe('Change scheduled stop point timing place', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);
@@ -322,8 +320,7 @@ describe('Change scheduled stop point timing place', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);

--- a/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-stop-point-in-journey-pattern.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-journey-pattern-refs/update-stop-point-in-journey-pattern.spec.ts
@@ -1,9 +1,10 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData } from '@datasets-generic/routesAndJourneyPatterns';
 import {
   journeyPatterns,
   scheduledStopPointInJourneyPattern,
 } from '@datasets-generic/routesAndJourneyPatterns/journey-patterns';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   ScheduledStopPointInJourneyPattern,
   scheduledStopPointInJourneyPatternProps,
@@ -46,7 +47,7 @@ describe('Update scheduled stop point in journey pattern', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableConfig));
+  beforeEach(() => setupDb(dbConnection, routesAndJourneyPatternsTableData));
 
   const shouldReturnErrorResponse = (
     scheduledStopPoint: ScheduledStopPointInJourneyPattern,
@@ -86,8 +87,9 @@ describe('Update scheduled stop point in journey pattern', () => {
 
       const response = await queryTable(
         dbConnection,
-        'journey_pattern.scheduled_stop_point_in_journey_pattern',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema[
+          'journey_pattern.scheduled_stop_point_in_journey_pattern'
+        ],
       );
 
       expect(response.rowCount).toEqual(
@@ -176,8 +178,9 @@ describe('Update scheduled stop point in journey pattern', () => {
 
       const response = await queryTable(
         dbConnection,
-        'journey_pattern.scheduled_stop_point_in_journey_pattern',
-        routesAndJourneyPatternsTableConfig,
+        genericNetworkDbSchema[
+          'journey_pattern.scheduled_stop_point_in_journey_pattern'
+        ],
       );
 
       expect(response.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/route-link-infra-link-direction/insert-route-with-links.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-link-infra-link-direction/insert-route-with-links.spec.ts
@@ -1,5 +1,5 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import {
@@ -7,6 +7,7 @@ import {
   routes,
 } from '@datasets-generic/defaultSetup/routes';
 import { buildRoute } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   InfrastructureLinkAlongRoute,
   Route,
@@ -80,7 +81,7 @@ describe('Insert route with links', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   describe("containing a link whose direction conflicts with its infrastructure link's direction", () => {
     const shouldReturnErrorResponse = (
@@ -110,14 +111,17 @@ describe('Insert route with links', () => {
           body: { query: buildMutation(linksToBeInserted) },
         });
 
-        const routeResponse = await queryTable(dbConnection, 'route.route');
+        const routeResponse = await queryTable(
+          dbConnection,
+          genericNetworkDbSchema['route.route'],
+        );
 
         expect(routeResponse.rowCount).toEqual(routes.length);
         expect(routeResponse.rows).toEqual(expect.arrayContaining(routes));
 
         const infraLinksResponse = await queryTable(
           dbConnection,
-          'route.infrastructure_link_along_route',
+          genericNetworkDbSchema['route.infrastructure_link_along_route'],
         );
 
         expect(infraLinksResponse.rowCount).toEqual(
@@ -191,7 +195,10 @@ describe('Insert route with links', () => {
           body: { query: buildMutation(linksToBeInserted) },
         });
 
-        const routeResponse = await queryTable(dbConnection, 'route.route');
+        const routeResponse = await queryTable(
+          dbConnection,
+          genericNetworkDbSchema['route.route'],
+        );
 
         expect(routeResponse.rowCount).toEqual(routes.length + 1);
         expect(routeResponse.rows).toEqual(
@@ -206,7 +213,7 @@ describe('Insert route with links', () => {
 
         const infraLinksResponse = await queryTable(
           dbConnection,
-          'route.infrastructure_link_along_route',
+          genericNetworkDbSchema['route.infrastructure_link_along_route'],
         );
 
         expect(infraLinksResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/route-link-infra-link-direction/update-infra-link.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-link-infra-link-direction/update-infra-link.spec.ts
@@ -1,6 +1,7 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   InfrastructureLink,
   infrastructureLinkProps,
@@ -40,7 +41,7 @@ describe('Update infrastructure link', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   describe("whose direction conflicts with a route link's direction", () => {
     const shouldReturnErrorResponse = (
@@ -72,7 +73,7 @@ describe('Update infrastructure link', () => {
 
         const response = await queryTable(
           dbConnection,
-          'infrastructure_network.infrastructure_link',
+          genericNetworkDbSchema['infrastructure_network.infrastructure_link'],
         );
 
         expect(response.rowCount).toEqual(infrastructureLinks.length);
@@ -162,7 +163,9 @@ describe('Update infrastructure link', () => {
 
           const response = await queryTable(
             dbConnection,
-            'infrastructure_network.infrastructure_link',
+            genericNetworkDbSchema[
+              'infrastructure_network.infrastructure_link'
+            ],
           );
 
           expect(response.rowCount).toEqual(infrastructureLinks.length);

--- a/test/hasura/generic/integration-tests/data-integrity/route-link-infra-link-direction/update-route-link.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/route-link-infra-link-direction/update-route-link.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { infrastructureLinkAlongRoute } from '@datasets-generic/defaultSetup/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   InfrastructureLinkAlongRoute,
   infrastructureLinkAlongRouteProps,
@@ -45,7 +46,7 @@ describe('Update route link', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   describe("whose direction conflicts with its infrastructure link's direction", () => {
     const shouldReturnErrorResponse = (
@@ -91,7 +92,7 @@ describe('Update route link', () => {
 
         const response = await queryTable(
           dbConnection,
-          'route.infrastructure_link_along_route',
+          genericNetworkDbSchema['route.infrastructure_link_along_route'],
         );
 
         expect(response.rowCount).toEqual(infrastructureLinkAlongRoute.length);
@@ -224,7 +225,7 @@ describe('Update route link', () => {
 
         const response = await queryTable(
           dbConnection,
-          'route.infrastructure_link_along_route',
+          genericNetworkDbSchema['route.infrastructure_link_along_route'],
         );
 
         expect(response.rowCount).toEqual(infrastructureLinkAlongRoute.length);

--- a/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-direction/insert-stop-point.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-direction/insert-stop-point.spec.ts
@@ -1,6 +1,8 @@
 import * as config from '@config';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -13,8 +15,8 @@ import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
 import { expectErrorResponse } from '@util/response';
 import {
+  getPartialTableData,
   getPropNameArray,
-  getTableConfigArray,
   queryTable,
   setupDb,
 } from '@util/setup';
@@ -80,7 +82,7 @@ describe('Insert scheduled stop point', () => {
   beforeEach(() =>
     setupDb(
       dbConnection,
-      getTableConfigArray([
+      getPartialTableData(defaultGenericNetworkDbData, [
         'infrastructure_network.infrastructure_link',
         'infrastructure_network.vehicle_submode_on_infrastructure_link',
         'service_pattern.scheduled_stop_point_invariant',
@@ -120,7 +122,7 @@ describe('Insert scheduled stop point', () => {
 
         const response = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point',
+          genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
         );
 
         expect(response.rowCount).toEqual(scheduledStopPoints.length);
@@ -218,7 +220,7 @@ describe('Insert scheduled stop point', () => {
 
         const response = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point',
+          genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
         );
 
         expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);

--- a/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-direction/update-infra-link.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-direction/update-infra-link.spec.ts
@@ -1,5 +1,7 @@
 import * as config from '@config';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   InfrastructureLink,
   infrastructureLinkProps,
@@ -11,8 +13,8 @@ import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
 import { expectErrorResponse } from '@util/response';
 import {
+  getPartialTableData,
   getPropNameArray,
-  getTableConfigArray,
   queryTable,
   setupDb,
 } from '@util/setup';
@@ -47,7 +49,7 @@ describe('Update infrastructure link', () => {
   beforeEach(() =>
     setupDb(
       dbConnection,
-      getTableConfigArray([
+      getPartialTableData(defaultGenericNetworkDbData, [
         'infrastructure_network.infrastructure_link',
         'infrastructure_network.vehicle_submode_on_infrastructure_link',
         'service_pattern.scheduled_stop_point_invariant',
@@ -89,7 +91,7 @@ describe('Update infrastructure link', () => {
 
         const response = await queryTable(
           dbConnection,
-          'infrastructure_network.infrastructure_link',
+          genericNetworkDbSchema['infrastructure_network.infrastructure_link'],
         );
 
         expect(response.rowCount).toEqual(infrastructureLinks.length);
@@ -179,7 +181,9 @@ describe('Update infrastructure link', () => {
 
           const response = await queryTable(
             dbConnection,
-            'infrastructure_network.infrastructure_link',
+            genericNetworkDbSchema[
+              'infrastructure_network.infrastructure_link'
+            ],
           );
 
           expect(response.rowCount).toEqual(infrastructureLinks.length);

--- a/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-direction/update-stop-point.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-direction/update-stop-point.spec.ts
@@ -1,6 +1,8 @@
 import * as config from '@config';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -12,8 +14,8 @@ import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
 import { expectErrorResponse } from '@util/response';
 import {
+  getPartialTableData,
   getPropNameArray,
-  getTableConfigArray,
   queryTable,
   setupDb,
 } from '@util/setup';
@@ -48,7 +50,7 @@ describe('Update scheduled stop point', () => {
   beforeEach(() =>
     setupDb(
       dbConnection,
-      getTableConfigArray([
+      getPartialTableData(defaultGenericNetworkDbData, [
         'infrastructure_network.infrastructure_link',
         'infrastructure_network.vehicle_submode_on_infrastructure_link',
         'service_pattern.scheduled_stop_point_invariant',
@@ -90,7 +92,7 @@ describe('Update scheduled stop point', () => {
 
         const response = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point',
+          genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
         );
 
         expect(response.rowCount).toEqual(scheduledStopPoints.length);
@@ -215,7 +217,7 @@ describe('Update scheduled stop point', () => {
 
           const response = await queryTable(
             dbConnection,
-            'service_pattern.scheduled_stop_point',
+            genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
           );
 
           expect(response.rowCount).toEqual(scheduledStopPoints.length);

--- a/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-vehicle-mode/delete-infrastructure-link.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-vehicle-mode/delete-infrastructure-link.spec.ts
@@ -1,9 +1,10 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import {
   infrastructureLinks,
   vehicleSubmodeOnInfrastructureLink,
 } from '@datasets-generic/defaultSetup/infrastructure-links';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { infrastructureLinkProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -31,7 +32,7 @@ describe('Delete infrastructure link', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   describe('which is referenced by a scheduled stop point', () => {
     const toBeDeleted = infrastructureLinks[0];
@@ -53,7 +54,7 @@ describe('Delete infrastructure link', () => {
 
       const infraLinkResponse = await queryTable(
         dbConnection,
-        'infrastructure_network.infrastructure_link',
+        genericNetworkDbSchema['infrastructure_network.infrastructure_link'],
       );
 
       expect(infraLinkResponse.rowCount).toEqual(infrastructureLinks.length);
@@ -65,7 +66,9 @@ describe('Delete infrastructure link', () => {
 
       const vehicleSubModeResponse = await queryTable(
         dbConnection,
-        'infrastructure_network.vehicle_submode_on_infrastructure_link',
+        genericNetworkDbSchema[
+          'infrastructure_network.vehicle_submode_on_infrastructure_link'
+        ],
       );
 
       expect(vehicleSubModeResponse.rowCount).toEqual(
@@ -105,7 +108,7 @@ describe('Delete infrastructure link', () => {
 
       const infraLinkResponse = await queryTable(
         dbConnection,
-        'infrastructure_network.infrastructure_link',
+        genericNetworkDbSchema['infrastructure_network.infrastructure_link'],
       );
 
       expect(infraLinkResponse.rowCount).toEqual(
@@ -126,7 +129,9 @@ describe('Delete infrastructure link', () => {
 
       const vehicleSubModeResponse = await queryTable(
         dbConnection,
-        'infrastructure_network.vehicle_submode_on_infrastructure_link',
+        genericNetworkDbSchema[
+          'infrastructure_network.vehicle_submode_on_infrastructure_link'
+        ],
       );
 
       expect(vehicleSubModeResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-vehicle-mode/insert-scheduled-stop-point.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-vehicle-mode/insert-scheduled-stop-point.spec.ts
@@ -1,11 +1,12 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import {
   scheduledStopPointInvariants,
   scheduledStopPoints,
   vehicleModeOnScheduledStopPoint,
 } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -76,7 +77,7 @@ describe('Insert scheduled stop point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   describe("whose vehicle mode conflicts with its infrastructure link's vehicle sub mode", () => {
     const shouldReturnErrorResponse = (vehicleMode?: VehicleMode) =>
@@ -102,7 +103,7 @@ describe('Insert scheduled stop point', () => {
 
         const stopPointResponse = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point',
+          genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
         );
 
         expect(stopPointResponse.rowCount).toEqual(scheduledStopPoints.length);
@@ -112,7 +113,9 @@ describe('Insert scheduled stop point', () => {
 
         const vehicleModeResponse = await queryTable(
           dbConnection,
-          'service_pattern.vehicle_mode_on_scheduled_stop_point',
+          genericNetworkDbSchema[
+            'service_pattern.vehicle_mode_on_scheduled_stop_point'
+          ],
         );
 
         expect(vehicleModeResponse.rowCount).toEqual(
@@ -124,7 +127,9 @@ describe('Insert scheduled stop point', () => {
 
         const stopPointInvariantResponse = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point_invariant',
+          genericNetworkDbSchema[
+            'service_pattern.scheduled_stop_point_invariant'
+          ],
         );
 
         expect(stopPointInvariantResponse.rowCount).toEqual(
@@ -194,7 +199,7 @@ describe('Insert scheduled stop point', () => {
 
         const stopPointResponse = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point',
+          genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
         );
 
         expect(stopPointResponse.rowCount).toEqual(
@@ -216,7 +221,9 @@ describe('Insert scheduled stop point', () => {
 
         const vehicleModeResponse = await queryTable(
           dbConnection,
-          'service_pattern.vehicle_mode_on_scheduled_stop_point',
+          genericNetworkDbSchema[
+            'service_pattern.vehicle_mode_on_scheduled_stop_point'
+          ],
         );
 
         expect(vehicleModeResponse.rowCount).toEqual(
@@ -235,7 +242,9 @@ describe('Insert scheduled stop point', () => {
 
         const stopPointInvariantResponse = await queryTable(
           dbConnection,
-          'service_pattern.scheduled_stop_point_invariant',
+          genericNetworkDbSchema[
+            'service_pattern.scheduled_stop_point_invariant'
+          ],
         );
 
         expect(stopPointInvariantResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-vehicle-mode/update-scheduled-stop-point.spec.ts
+++ b/test/hasura/generic/integration-tests/data-integrity/stop-point-infra-link-vehicle-mode/update-scheduled-stop-point.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   ScheduledStopPoint,
   scheduledStopPointProps,
@@ -46,7 +47,7 @@ describe('Update scheduled stop point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   describe('with infra link id referencing link with incompatible sub mode "generic_ferry"', () => {
     const toBeUpdated: Partial<ScheduledStopPoint> = {
@@ -75,7 +76,7 @@ describe('Update scheduled stop point', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);
@@ -121,7 +122,7 @@ describe('Update scheduled stop point', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);

--- a/test/hasura/generic/integration-tests/function-get_distances_between_stop_points/get-distances-between-stops-points-by-routes.spec.ts
+++ b/test/hasura/generic/integration-tests/function-get_distances_between_stop_points/get-distances-between-stops-points-by-routes.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig as baseTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData as baseTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
 import { journeyPatterns } from '@datasets-generic/routesAndJourneyPatterns/journey-patterns';
 import { scheduledStopPoints as sourceScheduledStopPoints } from '@datasets-generic/routesAndJourneyPatterns/scheduled-stop-points';
+import { GenericNetworkDbTables } from '@datasets-generic/schema';
 import {
   ScheduledStopPoint,
   VehicleMode,
@@ -32,7 +33,7 @@ describe('Function service_pattern.get_distances_between_stop_points_by_routes',
 
   const getTableDataToBePopulated = (
     scheduledStopPoints: ScheduledStopPoint[] = baseScheduledStopPoints,
-  ): TableLikeConfig[] => {
+  ): TableData<GenericNetworkDbTables>[] => {
     const tableConfig = [...baseTableConfig];
 
     const scheduledStopPointsIndex = baseTableConfig.findIndex((elem) => {
@@ -76,7 +77,7 @@ describe('Function service_pattern.get_distances_between_stop_points_by_routes',
   };
 
   const getDistancesBetweenStopPoints = async (
-    dataset: TableLikeConfig[],
+    dataset: TableData<GenericNetworkDbTables>[],
     routeIds: string[],
     observationDate: LocalDate,
   ): Promise<Array<StopIntervalLength>> => {

--- a/test/hasura/generic/integration-tests/function-get_distances_between_stop_points/get-distances-between-stops-points-in-journey-patterns.spec.ts
+++ b/test/hasura/generic/integration-tests/function-get_distances_between_stop_points/get-distances-between-stops-points-in-journey-patterns.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { routesAndJourneyPatternsTableConfig as baseTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
+import { routesAndJourneyPatternsTableData as baseTableConfig } from '@datasets-generic/routesAndJourneyPatterns';
 import { infrastructureLinks as sourceInfrastructureLinks } from '@datasets-generic/routesAndJourneyPatterns/infrastructure-links';
 import { journeyPatterns } from '@datasets-generic/routesAndJourneyPatterns/journey-patterns';
 import { scheduledStopPoints as sourceScheduledStopPoints } from '@datasets-generic/routesAndJourneyPatterns/scheduled-stop-points';
+import { GenericNetworkDbTables } from '@datasets-generic/schema';
 import {
   InfrastructureLink,
   ScheduledStopPoint,
@@ -47,7 +48,7 @@ describe('Function service_pattern.get_distances_between_stop_points_in_journey_
   const getTableDataToBePopulated = (
     scheduledStopPoints: ScheduledStopPoint[] = baseScheduledStopPoints,
     infrastructureLinks: InfrastructureLink[] = baseInfrastructureLinks,
-  ): TableLikeConfig[] => {
+  ): TableData<GenericNetworkDbTables>[] => {
     const tableConfig = [...baseTableConfig];
 
     const scheduledStopPointsIndex = baseTableConfig.findIndex((elem) => {
@@ -119,7 +120,7 @@ describe('Function service_pattern.get_distances_between_stop_points_in_journey_
   };
 
   const getDistancesBetweenStopPoints = async (
-    dataset: TableLikeConfig[],
+    dataset: TableData<GenericNetworkDbTables>[],
     journeyPatternIds: string[],
     observationDate: LocalDate,
     includeDraftStopPoints = false,

--- a/test/hasura/generic/integration-tests/mutations/route/delete.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/route/delete.spec.ts
@@ -1,6 +1,7 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { routes } from '@datasets-generic/defaultSetup/routes';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -33,7 +34,7 @@ describe('Delete route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   it('should return correct response', async () => {
     const response = await rp.post({
@@ -58,7 +59,10 @@ describe('Delete route', () => {
       body: { query: mutation },
     });
 
-    const response = await queryTable(dbConnection, 'route.route');
+    const response = await queryTable(
+      dbConnection,
+      genericNetworkDbSchema['route.route'],
+    );
 
     expect(response.rowCount).toEqual(routes.length - 1);
 

--- a/test/hasura/generic/integration-tests/mutations/route/insert.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/route/insert.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
 import { buildRoute } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, RouteDirection, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -41,7 +42,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   it('should return correct response', async () => {
     const response = await rp.post({
@@ -76,7 +77,10 @@ describe('Insert route', () => {
       body: { query: mutation },
     });
 
-    const response = await queryTable(dbConnection, 'route.route');
+    const response = await queryTable(
+      dbConnection,
+      genericNetworkDbSchema['route.route'],
+    );
 
     expect(response.rowCount).toEqual(routes.length + 1);
 

--- a/test/hasura/generic/integration-tests/mutations/route/update.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/route/update.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { routes } from '@datasets-generic/defaultSetup/routes';
 import { buildLocalizedString } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -45,7 +46,7 @@ describe('Update route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   it('should return correct response', async () => {
     const response = await rp.post({
@@ -70,7 +71,10 @@ describe('Update route', () => {
       body: { query: mutation },
     });
 
-    const response = await queryTable(dbConnection, 'route.route');
+    const response = await queryTable(
+      dbConnection,
+      genericNetworkDbSchema['route.route'],
+    );
 
     expect(response.rowCount).toEqual(routes.length);
 

--- a/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/delete.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/delete.spec.ts
@@ -1,15 +1,17 @@
 import * as config from '@config';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import {
   scheduledStopPointInvariants,
   scheduledStopPoints,
 } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { scheduledStopPointProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import '@util/matchers';
 import {
+  getPartialTableData,
   getPropNameArray,
-  getTableConfigArray,
   queryTable,
   setupDb,
 } from '@util/setup';
@@ -41,7 +43,7 @@ describe('Delete scheduled_stop_point', () => {
   beforeEach(() =>
     setupDb(
       dbConnection,
-      getTableConfigArray([
+      getPartialTableData(defaultGenericNetworkDbData, [
         'infrastructure_network.infrastructure_link',
         'infrastructure_network.vehicle_submode_on_infrastructure_link',
         'service_pattern.scheduled_stop_point_invariant',
@@ -76,7 +78,7 @@ describe('Delete scheduled_stop_point', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPoints.length - 1);
@@ -95,7 +97,7 @@ describe('Delete scheduled_stop_point', () => {
 
     const stopPointInvariantResponse = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point_invariant',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point_invariant'],
     );
 
     expect(stopPointInvariantResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/insert-with-id.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/insert-with-id.spec.ts
@@ -1,10 +1,11 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import {
   scheduledStopPointInvariants,
   scheduledStopPoints,
 } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -73,7 +74,7 @@ describe('Insert scheduled_stop_point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   it('should return correct response', async () => {
     const response = await rp.post({
@@ -105,7 +106,7 @@ describe('Insert scheduled_stop_point', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);
@@ -124,7 +125,7 @@ describe('Insert scheduled_stop_point', () => {
 
     const stopPointInvariantResponse = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point_invariant',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point_invariant'],
     );
 
     expect(stopPointInvariantResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/insert-without-id.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/insert-without-id.spec.ts
@@ -1,10 +1,11 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import {
   scheduledStopPointInvariants,
   scheduledStopPoints,
 } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -72,7 +73,7 @@ describe('Insert scheduled_stop_point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   it('should return correct response', async () => {
     const response = await rp.post({
@@ -111,7 +112,7 @@ describe('Insert scheduled_stop_point', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);
@@ -131,7 +132,7 @@ describe('Insert scheduled_stop_point', () => {
 
     const stopPointInvariantResponse = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point_invariant',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point_invariant'],
     );
 
     expect(stopPointInvariantResponse.rowCount).toEqual(

--- a/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/update.spec.ts
+++ b/test/hasura/generic/integration-tests/mutations/scheduled-stop-point/update.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   ScheduledStopPoint,
   scheduledStopPointProps,
@@ -62,7 +63,7 @@ describe('Update scheduled_stop_point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   it('should return correct response', async () => {
     const response = await rp.post({
@@ -89,7 +90,7 @@ describe('Update scheduled_stop_point', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPoints.length);

--- a/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/line/insert-with-conflicts.spec.ts
+++ b/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/line/insert-with-conflicts.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { buildLine, buildLocalizedString } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Line, lineProps, VehicleMode } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -33,7 +34,7 @@ describe('Insert line', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (toBeInserted: Partial<Line>) =>
     it('should return error response', async () => {
@@ -52,7 +53,10 @@ describe('Insert line', () => {
         body: { query: buildMutation(toBeInserted) },
       });
 
-      const response = await queryTable(dbConnection, 'route.line');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.line'],
+      );
 
       expect(response.rowCount).toEqual(lines.length);
       expect(response.rows).toEqual(expect.arrayContaining(lines));

--- a/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/line/insert-without-conflicts.spec.ts
+++ b/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/line/insert-without-conflicts.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { buildLine, buildLocalizedString } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Line, lineProps, VehicleMode } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -32,7 +33,7 @@ describe('Insert line', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnCorrectResponse = (toBeInserted: Partial<Line>) =>
     it('should return correct response', async () => {
@@ -69,7 +70,10 @@ describe('Insert line', () => {
         body: { query: buildMutation(toBeInserted) },
       });
 
-      const response = await queryTable(dbConnection, 'route.line');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.line'],
+      );
 
       expect(response.rowCount).toEqual(lines.length + 1);
 

--- a/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/route/insert-with-conflicts.spec.ts
+++ b/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/route/insert-with-conflicts.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
 import { buildRoute } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, RouteDirection, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -33,7 +34,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (toBeInserted: Partial<Route>) =>
     it('should return error response', async () => {
@@ -52,7 +53,10 @@ describe('Insert route', () => {
         body: { query: buildMutation(toBeInserted) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length);
       expect(response.rows).toEqual(expect.arrayContaining(routes));

--- a/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/route/insert-without-conflicts.spec.ts
+++ b/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/route/insert-without-conflicts.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { lines } from '@datasets-generic/defaultSetup/lines';
 import { routes } from '@datasets-generic/defaultSetup/routes';
 import { buildRoute } from '@datasets-generic/factories';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import { Route, RouteDirection, routeProps } from '@datasets-generic/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -32,7 +33,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnCorrectResponse = (toBeInserted: Partial<Route>) =>
     it('should return correct response', async () => {
@@ -69,7 +70,10 @@ describe('Insert route', () => {
         body: { query: buildMutation(toBeInserted) },
       });
 
-      const response = await queryTable(dbConnection, 'route.route');
+      const response = await queryTable(
+        dbConnection,
+        genericNetworkDbSchema['route.route'],
+      );
 
       expect(response.rowCount).toEqual(routes.length + 1);
 

--- a/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-with-conflicts.spec.ts
+++ b/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-with-conflicts.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -48,7 +49,7 @@ describe('Insert scheduled stop point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnErrorResponse = (
     toBeInserted: Partial<ScheduledStopPoint>,
@@ -71,7 +72,7 @@ describe('Insert scheduled stop point', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length);

--- a/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-without-conflicts.spec.ts
+++ b/test/hasura/generic/integration-tests/priority-and-validity-period-constraints/scheduled-stop-point/insert-without-conflicts.spec.ts
@@ -1,7 +1,8 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import { scheduledStopPoints } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -47,7 +48,7 @@ describe('Insert scheduled stop point', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const shouldReturnCorrectResponse = (
     toBeInserted: Partial<ScheduledStopPoint>,
@@ -91,7 +92,7 @@ describe('Insert scheduled stop point', () => {
 
       const response = await queryTable(
         dbConnection,
-        'service_pattern.scheduled_stop_point',
+        genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
       );
 
       expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);

--- a/test/hasura/generic/unit-tests/function-insert_scheduled_stop_point_with_vehicle_mode/insert-scheduled-stop-point.spec.ts
+++ b/test/hasura/generic/unit-tests/function-insert_scheduled_stop_point_with_vehicle_mode/insert-scheduled-stop-point.spec.ts
@@ -1,11 +1,12 @@
 import * as config from '@config';
-import { defaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { infrastructureLinks } from '@datasets-generic/defaultSetup/infrastructure-links';
 import {
   scheduledStopPointInvariants,
   scheduledStopPoints,
   vehicleModeOnScheduledStopPoint,
 } from '@datasets-generic/defaultSetup/scheduled-stop-points';
+import { genericNetworkDbSchema } from '@datasets-generic/schema';
 import {
   LinkDirection,
   ScheduledStopPoint,
@@ -54,7 +55,7 @@ describe('Function insert_scheduled_stop_point_with_vehicle_mode', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, defaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultGenericNetworkDbData));
 
   const insertScheduledStopPointWithVehicleMode = async (
     scheduledStopPoint: ScheduledStopPoint,
@@ -85,7 +86,7 @@ describe('Function insert_scheduled_stop_point_with_vehicle_mode', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPoints.length + 1);
@@ -106,7 +107,9 @@ describe('Function insert_scheduled_stop_point_with_vehicle_mode', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.vehicle_mode_on_scheduled_stop_point',
+      genericNetworkDbSchema[
+        'service_pattern.vehicle_mode_on_scheduled_stop_point'
+      ],
     );
 
     expect(response.rowCount).toEqual(
@@ -137,7 +140,7 @@ describe('Function insert_scheduled_stop_point_with_vehicle_mode', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point_invariant',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point_invariant'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPointInvariants.length + 1);
@@ -163,7 +166,7 @@ describe('Function insert_scheduled_stop_point_with_vehicle_mode', () => {
 
     const response = await queryTable(
       dbConnection,
-      'service_pattern.scheduled_stop_point_invariant',
+      genericNetworkDbSchema['service_pattern.scheduled_stop_point_invariant'],
     );
 
     expect(response.rowCount).toEqual(scheduledStopPointInvariants.length);

--- a/test/hasura/generic/unit-tests/function-maximum_priority_validity_spans/route.spec.ts
+++ b/test/hasura/generic/unit-tests/function-maximum_priority_validity_spans/route.spec.ts
@@ -1,6 +1,6 @@
 import * as config from '@config';
 import { buildLocalizedString } from '@datasets-generic/factories';
-import { Route, RouteDirection, routeProps } from '@datasets-generic/types';
+import { Route, RouteDirection } from '@datasets-generic/types';
 import * as db from '@util/db';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
 import { nextDay, prevDay } from '@util/helpers';
@@ -41,7 +41,6 @@ describe('Function maximum_priority_validity_spans should return correct route r
       [
         {
           name: 'route.route',
-          props: routeProps,
           data: routeData,
         },
       ],

--- a/test/hasura/generic/unit-tests/function-maximum_priority_validity_spans/scheduled-stop-point.spec.ts
+++ b/test/hasura/generic/unit-tests/function-maximum_priority_validity_spans/scheduled-stop-point.spec.ts
@@ -2,16 +2,11 @@ import { networkDbConfig } from '@config';
 import { buildLocalizedString } from '@datasets-generic/factories';
 import {
   InfrastructureLink,
-  infrastructureLinkProps,
   JourneyPattern,
-  journeyPatternProps,
   LinkDirection,
   Route,
   RouteDirection,
-  routeProps,
   ScheduledStopPoint,
-  scheduledStopPointInJourneyPatternProps,
-  scheduledStopPointProps,
 } from '@datasets-generic/types';
 import {
   closeDbConnection,
@@ -102,29 +97,24 @@ describe('Function maximum_priority_validity_spans should return correct schedul
         {
           // infra link is needed, since it is used by the service_pattern.scheduled_stop_point view
           name: 'infrastructure_network.infrastructure_link',
-          props: infrastructureLinkProps,
           data: [infraLink],
         },
         {
           name: 'service_pattern.scheduled_stop_point',
-          props: scheduledStopPointProps,
           data: stopData,
         },
         // the scheduled stop points are filtered by route label, and because of this we have to
         // establish the connection: route -> journey pattern -> journey pattern in ssp -> ssp
         {
           name: 'route.route',
-          props: routeProps,
           data: [route],
         },
         {
           name: 'journey_pattern.journey_pattern',
-          props: journeyPatternProps,
           data: [journeyPattern],
         },
         {
           name: 'journey_pattern.scheduled_stop_point_in_journey_pattern',
-          props: scheduledStopPointInJourneyPatternProps,
           data: stopData.map((stop, index) => ({
             journey_pattern_id: journeyPattern.journey_pattern_id,
             scheduled_stop_point_label: stop.label,

--- a/test/hasura/hsl/datasets/defaultSetup/index.ts
+++ b/test/hasura/hsl/datasets/defaultSetup/index.ts
@@ -1,20 +1,21 @@
-import { defaultTableConfig as genericDefaultTableConfig } from '@datasets-generic/defaultSetup';
+import { defaultGenericNetworkDbData } from '@datasets-generic/defaultSetup';
 import { hslLines } from '@datasets-hsl/defaultSetup/lines';
 import { hslRoutes } from '@datasets-hsl/defaultSetup/routes';
-import { hslLineProps, hslRouteProps } from '@datasets-hsl/types';
+import { HslNetworkDbTables } from '@datasets-hsl/schema';
+import { mergeLists } from '@util/schema';
 
-const tableConfigHslOverrides: TableLikeConfig[] = [
-  { name: 'route.line', data: hslLines, props: hslLineProps },
-  { name: 'route.route', data: hslRoutes, props: hslRouteProps },
-];
-
-export const hslDefaultTableConfig: TableLikeConfig[] =
-  genericDefaultTableConfig.map((genericTableConfigEntry) => {
-    const override = tableConfigHslOverrides.find(
-      (hslConfigEntry) =>
-        genericTableConfigEntry.name === hslConfigEntry.name &&
-        genericTableConfigEntry.isView === hslConfigEntry.isView,
-    );
-
-    return override || genericTableConfigEntry;
-  });
+export const defaultHslNetworkDbData: TableData<HslNetworkDbTables>[] =
+  mergeLists(
+    defaultGenericNetworkDbData,
+    [
+      {
+        name: 'route.line',
+        data: hslLines,
+      },
+      {
+        name: 'route.route',
+        data: hslRoutes,
+      },
+    ],
+    (tableSchema) => tableSchema.name,
+  );

--- a/test/hasura/hsl/datasets/schema.ts
+++ b/test/hasura/hsl/datasets/schema.ts
@@ -1,0 +1,21 @@
+import {
+  genericNetworkDbSchema,
+  genericNetworkDbTables,
+} from '@datasets-generic/schema';
+import { hslLineProps, hslRouteProps } from '@datasets-hsl/types';
+
+// extend with hsl data model tables on demand
+export const hslNetworkDbTables = [...genericNetworkDbTables] as const;
+export type HslNetworkDbTables = typeof hslNetworkDbTables[number];
+
+export const hslNetworkDbSchema: TableSchemaMap<HslNetworkDbTables> = {
+  ...genericNetworkDbSchema,
+  'route.line': {
+    name: 'route.line',
+    props: hslLineProps,
+  },
+  'route.route': {
+    name: 'route.route',
+    props: hslRouteProps,
+  },
+};

--- a/test/hasura/hsl/integration-tests/data-integrity/line-routes/variant/insert-route.spec.ts
+++ b/test/hasura/hsl/integration-tests/data-integrity/line-routes/variant/insert-route.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { hslDefaultTableConfig } from '@datasets-hsl/defaultSetup';
+import { defaultHslNetworkDbData } from '@datasets-hsl/defaultSetup';
 import { hslLines } from '@datasets-hsl/defaultSetup/lines';
 import { hslRoutes } from '@datasets-hsl/defaultSetup/routes';
 import { buildHslRoute } from '@datasets-hsl/factories';
+import { hslNetworkDbSchema } from '@datasets-hsl/schema';
 import { HslRoute, hslRouteProps, RouteDirection } from '@datasets-hsl/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -56,7 +57,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, hslDefaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultHslNetworkDbData));
 
   const shouldReturnErrorResponse = (
     label: string,
@@ -85,8 +86,7 @@ describe('Insert route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.route',
-        hslDefaultTableConfig,
+        hslNetworkDbSchema['route.route'],
       );
 
       expect(response.rowCount).toEqual(hslRoutes.length);
@@ -140,8 +140,7 @@ describe('Insert route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.route',
-        hslDefaultTableConfig,
+        hslNetworkDbSchema['route.route'],
       );
 
       expect(response.rowCount).toEqual(hslRoutes.length + 1);

--- a/test/hasura/hsl/integration-tests/priority-and-validity-period-constraints/route/insert-without-conflicts.spec.ts
+++ b/test/hasura/hsl/integration-tests/priority-and-validity-period-constraints/route/insert-without-conflicts.spec.ts
@@ -1,8 +1,9 @@
 import * as config from '@config';
-import { hslDefaultTableConfig } from '@datasets-hsl/defaultSetup';
+import { defaultHslNetworkDbData } from '@datasets-hsl/defaultSetup';
 import { hslLines } from '@datasets-hsl/defaultSetup/lines';
 import { hslRoutes } from '@datasets-hsl/defaultSetup/routes';
 import { buildHslRoute } from '@datasets-hsl/factories';
+import { hslNetworkDbSchema } from '@datasets-hsl/schema';
 import { HslRoute, hslRouteProps, RouteDirection } from '@datasets-hsl/types';
 import * as dataset from '@util/dataset';
 import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
@@ -32,7 +33,7 @@ describe('Insert route', () => {
 
   afterAll(() => closeDbConnection(dbConnection));
 
-  beforeEach(() => setupDb(dbConnection, hslDefaultTableConfig));
+  beforeEach(() => setupDb(dbConnection, defaultHslNetworkDbData));
 
   const shouldReturnCorrectResponse = (toBeInserted: Partial<HslRoute>) =>
     it('should return correct response', async () => {
@@ -73,8 +74,7 @@ describe('Insert route', () => {
 
       const response = await queryTable(
         dbConnection,
-        'route.route',
-        hslDefaultTableConfig,
+        hslNetworkDbSchema['route.route'],
       );
 
       expect(response.rowCount).toEqual(hslRoutes.length + 1);

--- a/test/hasura/types.d.ts
+++ b/test/hasura/types.d.ts
@@ -8,27 +8,25 @@ type GeoProperty = {
 };
 type Property = string | GeoProperty;
 
-type PropArray = Property[];
-
-type TableLikeConfigCommonProps = {
-  name: string;
+type TableSchema<TTableName extends readonly string> = {
+  name: TTableName;
   props: Property[];
 };
+// note: the table's name appears both in the key (for easy searchability) and in the schema object
+// (for encapsulating data that belongs together for querying)
+type TableSchemaMap<TTableName extends readonly string> = Record<
+  TTableName,
+  TableSchema<TTableName>
+>;
 
 type JsonDataSource = Record<string, unknown>[];
 type FileDataSource = string;
 type DataSource = JsonDataSource | FileDataSource;
-type TableConfig = TableLikeConfigCommonProps & {
+
+type TableData<TTableName extends readonly string> = {
+  name: TTableName;
   data: DataSource;
-  isView?: never;
 };
-
-type ViewConfig = TableLikeConfigCommonProps & {
-  data?: never;
-  isView: true;
-};
-
-type TableLikeConfig = TableConfig | ViewConfig;
 
 // using ExplicitAny instead of unknown so that also interface types would be compatible
 type PlainObject = Record<string, ExplicitAny>;

--- a/test/hasura/util/schema.ts
+++ b/test/hasura/util/schema.ts
@@ -1,0 +1,22 @@
+import differenceBy from 'lodash/differenceBy';
+
+export type ValueFunction<TItem> = (item: TItem) => ExplicitAny;
+export const mergeLists = <TItem extends ExplicitAny>(
+  originalItems: TItem[],
+  upsertItems: TItem[],
+  valueFunction: ValueFunction<TItem>,
+): TItem[] => {
+  // these items didn't exist in the original list, will be added as new items
+  const newItems = differenceBy(upsertItems, originalItems, valueFunction);
+
+  // these items do exist in the original list, they are replaced
+  const replacedItems = originalItems.reduce<TItem[]>((result, currentItem) => {
+    const replacedItem = upsertItems.find(
+      (item) => valueFunction(item) === valueFunction(currentItem),
+    );
+    return [...result, replacedItem || currentItem];
+  }, []);
+
+  // append the new items after the replaced items
+  return [...replacedItems, ...newItems];
+};


### PR DESCRIPTION
This enables easier separation between generic and hsl schema, also simplifies modifying the default dataset for special tests' needs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/140)
<!-- Reviewable:end -->
