### PR TITLE
Make legacyHslMunicipalityCode nullable

### DIFF
--- a/migrations/hsl/default/1675756038253_make_legacy_hsl_municipality_code_nullable/down.sql
+++ b/migrations/hsl/default/1675756038253_make_legacy_hsl_municipality_code_nullable/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE route.line
+  ALTER COLUMN legacy_hsl_municipality_code SET NOT NULL;
+
+ALTER TABLE route.route
+  ALTER COLUMN legacy_hsl_municipality_code SET NOT NULL;

--- a/migrations/hsl/default/1675756038253_make_legacy_hsl_municipality_code_nullable/up.sql
+++ b/migrations/hsl/default/1675756038253_make_legacy_hsl_municipality_code_nullable/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE route.line
+  ALTER COLUMN legacy_hsl_municipality_code DROP NOT NULL;
+
+ALTER TABLE route.route
+  ALTER COLUMN legacy_hsl_municipality_code DROP NOT NULL;


### PR DESCRIPTION
Because of course if it is NOT NULL we couldn't create new routes/lines from Jore 4 UI until it can set the field. Which it can't currently, and not sure yet if it even should.
So, make this nullable until we specify how this should be handled for new routes/lines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/144)
<!-- Reviewable:end -->
