### PR TITLE
Add timetables function tracking

### DIFF
--- a/metadata/generic/databases/databases.yaml
+++ b/metadata/generic/databases/databases.yaml
@@ -34,3 +34,4 @@
     type_names:
       prefix: timetables_
   tables: "!include timetables/tables/tables.yaml"
+  functions: "!include timetables/functions/functions.yaml"


### PR DESCRIPTION
This was disabled in an earlier commit probably by accident