### PR TITLE
No longer build seed image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,14 +51,6 @@ jobs:
             --tag $IMAGE_NAME:hsl-$COMMIT_ID \
             .
 
-          docker buildx build \
-            --push \
-            --platform linux/amd64,linux/arm64 \
-            --target hasura-seed \
-            --cache-from type=registry,ref=$IMAGE_NAME:seed \
-            --tag $IMAGE_NAME:seed-$COMMIT_ID \
-            .
-
       - name: Build and push :latest tag to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
@@ -76,14 +68,6 @@ jobs:
             --target hasura-hsl \
             --cache-to type=registry,ref=$IMAGE_NAME:hsl,mode=max \
             --tag $IMAGE_NAME:latest \
-            .
-
-          docker buildx build \
-            --push \
-            --platform linux/amd64,linux/arm64 \
-            --target hasura-seed \
-            --cache-to type=registry,ref=$IMAGE_NAME:seed,mode=max \
-            --tag $IMAGE_NAME:seed-data \
             .
 
   run_dump_tests:
@@ -115,7 +99,7 @@ jobs:
 
     strategy:
       matrix:
-        imagePrefix: ['generic-', 'seed-', 'hsl-']
+        imagePrefix: ['generic-', 'hsl-']
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,3 @@ FROM hasura-generic AS hasura-hsl
 COPY ./migrations/hsl "${HASURA_GRAPHQL_MIGRATIONS_DIR}/"
 COPY ./metadata/hsl "${HASURA_GRAPHQL_METADATA_DIR}/hsl"
 RUN /app/scripts/merge-metadata.sh ${HASURA_GRAPHQL_METADATA_DIR}/hsl ${HASURA_GRAPHQL_METADATA_DIR}
-
-# extend the hasura-hsl image to also load some seed data as migrations
-FROM hasura-hsl AS hasura-seed
-
-# copy seed-data migrations
-COPY ./migrations/seed-data "${HASURA_GRAPHQL_MIGRATIONS_DIR}/"


### PR DESCRIPTION
- Keep seed data in repository for later implementation of migration tests as mentioned in HSLdevcom/jore4#1234

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/177)
<!-- Reviewable:end -->
