### PR TITLE
Change build target from generic to hsl

### DIFF
--- a/docker/docker-compose.custom.yml
+++ b/docker/docker-compose.custom.yml
@@ -6,7 +6,7 @@ services:
     # build and the docker image from the local repo
     build:
       context: ..
-      target: hasura-generic
+      target: hasura-hsl
     # Waiting for database to be ready to avoid startup delay due to initial crash
     # Note: this should only be done in development setups as Kubernetes does not allow waiting for services to be ready
     depends_on:


### PR DESCRIPTION
We develop more often in the hsl environment, so it makes more sense to keep it as 'hsl' in the version control. No need to constantly edit and stash it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/181)
<!-- Reviewable:end -->
