### PR TITLE
Add timing point related test for `scheduled_stop_point_in_journey_pattern`

### DIFF
--- a/test/hasura/generic/networkdb/integration-tests/data-integrity/route-journey-pattern-refs/update-stop-point-in-journey-pattern.spec.ts
+++ b/test/hasura/generic/networkdb/integration-tests/data-integrity/route-journey-pattern-refs/update-stop-point-in-journey-pattern.spec.ts
@@ -129,6 +129,20 @@ describe('Update scheduled stop point in journey pattern', () => {
     shouldNotModifyDatabase(scheduledStopPointInJourneyPattern[3], toBeUpdated);
   });
 
+  describe('when scheduled stop point is not associated with a timing place do not allow it to be set as a timing point in the journey pattern', () => {
+    const toBeUpdated = {
+      is_used_as_timing_point: true,
+    };
+
+    shouldReturnErrorResponse(
+      scheduledStopPointInJourneyPattern[1],
+      toBeUpdated,
+      'scheduled stop point must have a timing place attached if it is used as a timing point in a journey pattern',
+    );
+
+    shouldNotModifyDatabase(scheduledStopPointInJourneyPattern[1], toBeUpdated);
+  });
+
   describe('without conflict', () => {
     const original = scheduledStopPointInJourneyPattern[4];
     const toBeUpdated = {


### PR DESCRIPTION
Add an integration test to cover the case when a stop point in journey pattern is updated to a timing point when the stop point is not associated with a timing place.

An integration test for insert mutation already exists.

Resolves HSLdevcom/jore4#1043

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/183)
<!-- Reviewable:end -->
