### PR TITLE
Fix module resolution errors for Hasura tests in VS Code

### DIFF
--- a/test/hasura/.eslintrc.js
+++ b/test/hasura/.eslintrc.js
@@ -21,7 +21,9 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
-      typescript: {}, // this loads <rootdir>/tsconfig.json to eslint
+      typescript: {
+        project: __dirname,
+      },
     },
   },
   plugins: ['@typescript-eslint', 'jest'],


### PR DESCRIPTION
https://github.com/import-js/eslint-import-resolver-typescript/issues/74#issuecomment-850754909

Another fix would've been to move tsconfig file to root (or add new one that extends the test/hasura config), but this was cleaner.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/184)
<!-- Reviewable:end -->
