### PR TITLE
Fix internal utils migrations

### DIFF
--- a/migrations/generic/timetables/1632000000000_create_immutable_internal_utils/down.sql
+++ b/migrations/generic/timetables/1632000000000_create_immutable_internal_utils/down.sql
@@ -1,7 +1,1 @@
-DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_special ();
-
-DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_substitute_by_line_type ();
-
-DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_staging ();
-
-DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_draft ();
+DROP FUNCTION IF EXISTS internal_utils.const_priority_draft();

--- a/migrations/generic/timetables/1632000000000_create_immutable_internal_utils/up.sql
+++ b/migrations/generic/timetables/1632000000000_create_immutable_internal_utils/up.sql
@@ -1,15 +1,3 @@
-CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_substitute_by_line_type() RETURNS integer
-  LANGUAGE sql IMMUTABLE PARALLEL SAFE
-  AS $$SELECT 23$$;
-
-CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_special() RETURNS integer
-  LANGUAGE sql IMMUTABLE PARALLEL SAFE
-  AS $$SELECT 25$$;
-
-CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_draft() RETURNS integer
+CREATE OR REPLACE FUNCTION internal_utils.const_priority_draft() RETURNS integer
   LANGUAGE sql IMMUTABLE PARALLEL SAFE
   AS $$SELECT 30$$;
-
-CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_staging() RETURNS integer
-  LANGUAGE sql IMMUTABLE PARALLEL SAFE
-  AS $$SELECT 40$$;

--- a/migrations/generic/timetables/1685091101965_add_timetable_priority_internal_util_consts/down.sql
+++ b/migrations/generic/timetables/1685091101965_add_timetable_priority_internal_util_consts/down.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION internal_utils.const_priority_draft() RETURNS integer
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  AS $$SELECT 30$$;
+
+DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_special();
+
+DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_substitute_by_line_type();
+
+DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_staging();
+
+DROP FUNCTION IF EXISTS internal_utils.const_timetables_priority_draft();

--- a/migrations/generic/timetables/1685091101965_add_timetable_priority_internal_util_consts/up.sql
+++ b/migrations/generic/timetables/1685091101965_add_timetable_priority_internal_util_consts/up.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_substitute_by_line_type() RETURNS integer
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  AS $$SELECT 23$$;
+
+CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_special() RETURNS integer
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  AS $$SELECT 25$$;
+
+CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_draft() RETURNS integer
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  AS $$SELECT 30$$;
+
+CREATE OR REPLACE FUNCTION internal_utils.const_timetables_priority_staging() RETURNS integer
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE
+  AS $$SELECT 40$$;
+
+DROP FUNCTION IF EXISTS internal_utils.const_priority_draft();


### PR DESCRIPTION
There were an accidental change made to an old migration which was not an repeatable migration this caused the dev and test environments to crash, because the changes did not obviously come in to action. So in this commit we change the old migration like it was and create a new migration for these changes. Immutable functions can't be in repeatable migrations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/185)
<!-- Reviewable:end -->
