### PR TITLE
Add hsl timetables infra and tests

### DIFF
--- a/test/hasura/generic/timetablesdb/datasets/defaultSetup/vehicle-journeys.ts
+++ b/test/hasura/generic/timetablesdb/datasets/defaultSetup/vehicle-journeys.ts
@@ -27,6 +27,12 @@ export const vehicleJourneysByName = {
     journey_pattern_ref_id:
       journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
   },
+  v1MonFriJourney1Summer2023: {
+    vehicle_journey_id: '2c27c47f-8559-43f2-a572-9f302d6ba0ba',
+    block_id: vehicleServiceBlocksByName.v1MonFriSummer2023.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route234Outbound.journey_pattern_ref_id,
+  },
 };
 export const vehicleJourneys: VehicleJourney[] = Object.values(
   vehicleJourneysByName,

--- a/test/hasura/generic/timetablesdb/datasets/defaultSetup/vehicle-service-blocks.ts
+++ b/test/hasura/generic/timetablesdb/datasets/defaultSetup/vehicle-service-blocks.ts
@@ -17,6 +17,12 @@ export const vehicleServiceBlocksByName = {
     block_id: 'a8545f76-92ef-4d11-9351-9ed4b9ba0ffb',
     vehicle_service_id: vehicleServicesByName.v1Sun.vehicle_service_id,
   },
+  // Vehicle 1 Mon-Fri Summer 2023
+  v1MonFriSummer2023: {
+    block_id: '4570d049-4bc2-487e-bfb9-1ee798405c78',
+    vehicle_service_id:
+      vehicleServicesByName.v1MonFriSummer2023.vehicle_service_id,
+  },
 };
 export const vehicleServiceBlocks: VehicleServiceBlock[] = Object.values(
   vehicleServiceBlocksByName,

--- a/test/hasura/generic/timetablesdb/datasets/defaultSetup/vehicle-services.ts
+++ b/test/hasura/generic/timetablesdb/datasets/defaultSetup/vehicle-services.ts
@@ -24,6 +24,13 @@ export const vehicleServicesByName = {
     vehicle_schedule_frame_id:
       vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
   },
+  // vehicle 1, Mon-Fri, Summer 2023
+  v1MonFriSummer2023: {
+    vehicle_service_id: '125f8ee1-549e-48f2-97e0-318c407f2ca3',
+    day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+    vehicle_schedule_frame_id:
+      vehicleScheduleFramesByName.summer2023.vehicle_schedule_frame_id,
+  },
 };
 export const vehicleServices: VehicleService[] = Object.values(
   vehicleServicesByName,

--- a/test/hasura/generic/timetablesdb/datasets/factories.ts
+++ b/test/hasura/generic/timetablesdb/datasets/factories.ts
@@ -3,15 +3,16 @@ import { DateTime } from 'luxon';
 import { TimetablePriority, VehicleScheduleFrame } from './types';
 
 // can set either name_i18n (-> leave as is) or name (-> make i18n version)
-type EntityName =
+export type EntityName =
   | { name?: never; name_i18n: LocalizedString }
   | { name: string; name_i18n?: never };
 
 /**
  * Builds the name for the entity if the i18n attribute is not set
  */
-const buildName = <TEntity extends EntityName>(entityWithName: TEntity) =>
-  entityWithName.name_i18n || buildLocalizedString(entityWithName.name);
+export const buildName = <TEntity extends EntityName>(
+  entityWithName: TEntity,
+) => entityWithName.name_i18n || buildLocalizedString(entityWithName.name);
 
 export const buildVehicleScheduleFrame = (
   frame: RequiredKeys<

--- a/test/hasura/generic/timetablesdb/integration-tests/data-integrity/vehicle-schedule/journey-patterns-in-vehicle-service.spec.ts
+++ b/test/hasura/generic/timetablesdb/integration-tests/data-integrity/vehicle-schedule/journey-patterns-in-vehicle-service.spec.ts
@@ -66,7 +66,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
   it('should have created correct rows to denormalized table initially', async () => {
     const response = await getJourneyPatternsInVehicleServices();
     expectNoErrorResponse(response);
-    expect(response.rowCount).toEqual(2);
+    expect(response.rowCount).toEqual(3);
     expect(response.rows).toEqual(
       expect.arrayContaining([
         defaultDatasetRows.route123Outbound,
@@ -92,7 +92,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(2);
+      expect(response.rowCount).toEqual(3);
       expect(response.rows).toEqual(
         expect.arrayContaining([
           {
@@ -120,7 +120,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(3);
+      expect(response.rowCount).toEqual(4);
       expect(response.rows).toEqual(
         expect.arrayContaining([
           defaultDatasetRows.route123Outbound,
@@ -197,7 +197,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(5);
+      expect(response.rowCount).toEqual(6);
       expect(response.rows).toEqual(
         expect.arrayContaining([
           {
@@ -252,7 +252,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(2);
+      expect(response.rowCount).toEqual(3);
       expect(response.rows).toEqual(
         expect.arrayContaining([
           {
@@ -298,7 +298,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(1);
+      expect(response.rowCount).toEqual(2);
       expect(response.rows).toEqual(
         expect.arrayContaining([defaultDatasetRows.route123Inbound]),
       );
@@ -320,7 +320,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(3);
+      expect(response.rowCount).toEqual(4);
       expect(response.rows).toEqual(
         expect.arrayContaining([
           // One got removed from outbound...
@@ -359,7 +359,7 @@ describe('Denormalized references to journey patterns in vehicle services', () =
 
       const response = await getJourneyPatternsInVehicleServices();
       expectNoErrorResponse(response);
-      expect(response.rowCount).toEqual(2);
+      expect(response.rowCount).toEqual(3);
       expect(response.rows).toEqual(
         expect.arrayContaining([
           {

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/index.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/index.ts
@@ -1,0 +1,3 @@
+export * from './substitute-operating-days-by-line-types';
+export * from './timetables';
+export * from './utils';

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/expressBusServiceSaturday20230520.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/expressBusServiceSaturday20230520.ts
@@ -1,0 +1,19 @@
+import { TypeOfLine } from 'generic/networkdb/datasets/types';
+import { DateTime } from 'luxon';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const expressBusServiceSaturday20230520SubstituteOperatingDayByLineType =
+  {
+    substitute_operating_day_by_line_type_id:
+      '0967a31a-8304-4440-9a8e-18bb67b281a8',
+    type_of_line: TypeOfLine.ExpressBusService,
+    superseded_date: DateTime.fromISO('2023-05-20'),
+  };
+
+export const expressBusServiceSaturday20230520Dataset: TableData<HslTimetablesDbTables>[] =
+  [
+    {
+      name: 'service_calendar.substitute_operating_day_by_line_type',
+      data: [expressBusServiceSaturday20230520SubstituteOperatingDayByLineType],
+    },
+  ];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/index.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/index.ts
@@ -1,0 +1,2 @@
+export * from './expressBusServiceSaturday20230520';
+export * from './stoppingBusServiceSaturday20230520';

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/stoppingBusServiceSaturday20230520.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/stoppingBusServiceSaturday20230520.ts
@@ -1,0 +1,21 @@
+import { TypeOfLine } from 'generic/networkdb/datasets/types';
+import { DateTime } from 'luxon';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const stoppingBusServiceSaturday20230520SubstituteOperatingDayByLineType =
+  {
+    substitute_operating_day_by_line_type_id:
+      '88fbc283-9552-45d2-9365-60272f1e44f6',
+    type_of_line: TypeOfLine.StoppingBusService,
+    superseded_date: DateTime.fromISO('2023-05-20'),
+  };
+
+export const stoppingBusServiceSaturday20230520Dataset: TableData<HslTimetablesDbTables>[] =
+  [
+    {
+      name: 'service_calendar.substitute_operating_day_by_line_type',
+      data: [
+        stoppingBusServiceSaturday20230520SubstituteOperatingDayByLineType,
+      ],
+    },
+  ];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/draftSunApril2023Dataset.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/draftSunApril2023Dataset.ts
@@ -1,0 +1,65 @@
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { TimetablePriority } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
+import { buildHslVehicleScheduleFrame } from '../../factories';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const draftSunApril2023VehicleScheduleFrame = {
+  ...buildHslVehicleScheduleFrame({
+    vehicle_schedule_frame_id: '410b94d2-7465-44d9-a08f-8a5d1c2400b2',
+    validity_start: DateTime.fromISO('2023-04-01'),
+    validity_end: DateTime.fromISO('2023-04-30'),
+    priority: TimetablePriority.Draft,
+    name: 'Huhtikuun luonnos sunnuntait 2023',
+    created_at: DateTime.fromISO('2021-01-01T02:34:56.789+02:00'),
+  }),
+};
+
+export const draftSunApril2023VehicleService = {
+  vehicle_service_id: '66f4e1f0-9b41-4e8e-b4b8-82118e4aaa4e',
+  day_type_id: defaultDayTypeIds.SUNDAY,
+  vehicle_schedule_frame_id:
+    draftSunApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+};
+
+export const draftSunApril2023VehicleServiceBlock = {
+  block_id: '73c9fc5d-67b3-4a1a-ba6b-c74051c03066',
+  vehicle_service_id: draftSunApril2023VehicleService.vehicle_service_id,
+};
+
+export const draftSunApril2023VehicleJourneysByName = {
+  v1journey1: {
+    vehicle_journey_id: 'b2ebd040-4935-4d73-bdd5-b9aa39d2bb03',
+    block_id: draftSunApril2023VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1journey2: {
+    vehicle_journey_id: '09ac200a-b7cf-417d-95fd-b83ae9fe3060',
+    block_id: draftSunApril2023VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+};
+
+export const draftSunApril2023Dataset: TableData<HslTimetablesDbTables>[] = [
+  {
+    name: 'vehicle_schedule.vehicle_schedule_frame',
+    data: [draftSunApril2023VehicleScheduleFrame],
+  },
+  {
+    name: 'vehicle_service.vehicle_service',
+    data: [draftSunApril2023VehicleService],
+  },
+  {
+    name: 'vehicle_service.block',
+    data: [draftSunApril2023VehicleServiceBlock],
+  },
+  {
+    name: 'vehicle_journey.vehicle_journey',
+    data: [...Object.values(draftSunApril2023VehicleJourneysByName)],
+  },
+];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/draftSunApril2024Dataset.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/draftSunApril2024Dataset.ts
@@ -1,0 +1,65 @@
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { TimetablePriority } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
+import { buildHslVehicleScheduleFrame } from '../../factories';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const draftSunApril2024VehicleScheduleFrame = {
+  ...buildHslVehicleScheduleFrame({
+    vehicle_schedule_frame_id: '2a784a4c-b0bc-44c0-be9d-c8cea8915e73',
+    validity_start: DateTime.fromISO('2024-04-01'),
+    validity_end: DateTime.fromISO('2024-04-30'),
+    priority: TimetablePriority.Draft,
+    name: 'Huhtikuun luonnos sunnuntait 2024',
+    created_at: DateTime.fromISO('2021-01-01T02:34:56.789+02:00'),
+  }),
+};
+
+export const draftSunApril2024VehicleService = {
+  vehicle_service_id: 'fd7eb647-750c-4216-b2fa-a957525b7cfa',
+  day_type_id: defaultDayTypeIds.SUNDAY,
+  vehicle_schedule_frame_id:
+    draftSunApril2024VehicleScheduleFrame.vehicle_schedule_frame_id,
+};
+
+export const draftSunApril2024VehicleServiceBlock = {
+  block_id: '52718fb2-edff-4cb3-b8ce-2cb2fe90600a',
+  vehicle_service_id: draftSunApril2024VehicleService.vehicle_service_id,
+};
+
+export const draftSunApril2024VehicleJourneysByName = {
+  v1journey1: {
+    vehicle_journey_id: '773efcf2-11d9-4e1b-b84b-8d9200abd096',
+    block_id: draftSunApril2024VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1journey2: {
+    vehicle_journey_id: '33dea211-92e4-4fdc-a82b-57d91518dd38',
+    block_id: draftSunApril2024VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+};
+
+export const draftSunApril2024Dataset: TableData<HslTimetablesDbTables>[] = [
+  {
+    name: 'vehicle_schedule.vehicle_schedule_frame',
+    data: [draftSunApril2024VehicleScheduleFrame],
+  },
+  {
+    name: 'vehicle_service.vehicle_service',
+    data: [draftSunApril2024VehicleService],
+  },
+  {
+    name: 'vehicle_service.block',
+    data: [draftSunApril2024VehicleServiceBlock],
+  },
+  {
+    name: 'vehicle_journey.vehicle_journey',
+    data: [...Object.values(draftSunApril2024VehicleJourneysByName)],
+  },
+];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/index.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/index.ts
@@ -1,0 +1,5 @@
+export * from './draftSunApril2023Dataset';
+export * from './draftSunApril2024Dataset';
+export * from './specialAprilFools2023Dataset';
+export * from './stagingSunApril2024Dataset';
+export * from './temporarySatFirstHalfApril2023Dataset';

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/specialAprilFools2023Dataset.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/specialAprilFools2023Dataset.ts
@@ -1,0 +1,65 @@
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { TimetablePriority } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
+import { buildHslVehicleScheduleFrame } from '../../factories';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const specialAprilFools2023VehicleScheduleFrame =
+  buildHslVehicleScheduleFrame({
+    vehicle_schedule_frame_id: '9142d422-31c8-40b6-8c76-fcaabd004818',
+    validity_start: DateTime.fromISO('2023-04-01'),
+    validity_end: DateTime.fromISO('2023-04-01'),
+    priority: TimetablePriority.Special,
+    name: 'Aprillipäivä 2023',
+    created_at: DateTime.fromISO('2022-02-01T02:34:56.789+02:00'),
+  });
+
+export const specialAprilFools2023VehicleService = {
+  vehicle_service_id: 'b7de19ec-e336-45e9-a94b-fcd86f7c6512',
+  day_type_id: defaultDayTypeIds.SATURDAY,
+  vehicle_schedule_frame_id:
+    specialAprilFools2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+};
+
+export const specialAprilFools2023VehicleServiceBlock = {
+  block_id: '9c29207d-1dec-44c2-976a-292e6bd9f9dc',
+  vehicle_service_id: specialAprilFools2023VehicleService.vehicle_service_id,
+};
+
+export const specialAprilFools2023VehicleJourneysByName = {
+  v1journey1: {
+    vehicle_journey_id: 'cc0ca525-eb96-462e-9658-35cd91eaa17a',
+    block_id: specialAprilFools2023VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1journey2: {
+    vehicle_journey_id: '5fcabadd-ee62-4455-904b-c652c14b57f0',
+    block_id: specialAprilFools2023VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+};
+
+export const specialAprilFools2023Dataset: TableData<HslTimetablesDbTables>[] =
+  [
+    {
+      name: 'vehicle_schedule.vehicle_schedule_frame',
+      data: [specialAprilFools2023VehicleScheduleFrame],
+    },
+    {
+      name: 'vehicle_service.vehicle_service',
+      data: [specialAprilFools2023VehicleService],
+    },
+    {
+      name: 'vehicle_service.block',
+      data: [specialAprilFools2023VehicleServiceBlock],
+    },
+    {
+      name: 'vehicle_journey.vehicle_journey',
+      data: [...Object.values(specialAprilFools2023VehicleJourneysByName)],
+    },
+  ];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/stagingSunApril2024Dataset.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/stagingSunApril2024Dataset.ts
@@ -1,0 +1,65 @@
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { TimetablePriority } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
+import { buildHslVehicleScheduleFrame } from '../../factories';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const stagingSunApril2024VehicleScheduleFrame = {
+  ...buildHslVehicleScheduleFrame({
+    vehicle_schedule_frame_id: '48ca91b8-dfd3-4187-be10-c71ac8b73890',
+    validity_start: DateTime.fromISO('2024-04-01'),
+    validity_end: DateTime.fromISO('2024-04-30'),
+    priority: TimetablePriority.Staging,
+    name: 'Huhtikuun (staging) sunnuntait 2024',
+    created_at: DateTime.fromISO('2021-01-01T02:34:56.789+02:00'),
+  }),
+};
+
+export const stagingSunApril2024VehicleService = {
+  vehicle_service_id: 'd38dfb0d-ac87-47fa-bea5-60b08b246efe',
+  day_type_id: defaultDayTypeIds.SUNDAY,
+  vehicle_schedule_frame_id:
+    stagingSunApril2024VehicleScheduleFrame.vehicle_schedule_frame_id,
+};
+
+export const stagingSunApril2024VehicleServiceBlock = {
+  block_id: '29ef6616-e844-47ea-820f-f48330f26732',
+  vehicle_service_id: stagingSunApril2024VehicleService.vehicle_service_id,
+};
+
+export const stagingSunApril2024VehicleJourneysByName = {
+  v1journey1: {
+    vehicle_journey_id: '5eb5f451-a415-4497-98b9-e9146175225f',
+    block_id: stagingSunApril2024VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1journey2: {
+    vehicle_journey_id: '53861267-adf2-47a7-a8ea-671c051e10b0',
+    block_id: stagingSunApril2024VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+};
+
+export const stagingSunApril2024Dataset: TableData<HslTimetablesDbTables>[] = [
+  {
+    name: 'vehicle_schedule.vehicle_schedule_frame',
+    data: [stagingSunApril2024VehicleScheduleFrame],
+  },
+  {
+    name: 'vehicle_service.vehicle_service',
+    data: [stagingSunApril2024VehicleService],
+  },
+  {
+    name: 'vehicle_service.block',
+    data: [stagingSunApril2024VehicleServiceBlock],
+  },
+  {
+    name: 'vehicle_journey.vehicle_journey',
+    data: [...Object.values(stagingSunApril2024VehicleJourneysByName)],
+  },
+];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/temporarySatFirstHalfApril2023Dataset.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/timetables/temporarySatFirstHalfApril2023Dataset.ts
@@ -1,0 +1,69 @@
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { TimetablePriority } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
+import { buildHslVehicleScheduleFrame } from '../../factories';
+import { HslTimetablesDbTables } from '../../schema';
+
+export const temporarySatFirstHalfApril2023VehicleScheduleFrame = {
+  ...buildHslVehicleScheduleFrame({
+    vehicle_schedule_frame_id: 'f48ac8d9-5ecf-43b4-a6f9-cc14f2627e43',
+    validity_start: DateTime.fromISO('2023-04-01'),
+    validity_end: DateTime.fromISO('2023-04-15'),
+    priority: TimetablePriority.Temporary,
+    name: 'Huhtikuun ensimmäisen puoliskon lauantait 2023',
+    created_at: DateTime.fromISO('2021-01-01T02:34:56.789+02:00'),
+  }),
+};
+
+export const temporarySatFirstHalfApril2023VehicleService = {
+  vehicle_service_id: 'c2b88679-abbb-4f4f-a6af-90522a24825c',
+  day_type_id: defaultDayTypeIds.SATURDAY,
+  vehicle_schedule_frame_id:
+    temporarySatFirstHalfApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+};
+
+export const temporarySatFirstHalfApril2023VehicleServiceBlock = {
+  block_id: '55ae7f82-b854-4875-bea8-3192e65f78ef',
+  vehicle_service_id:
+    temporarySatFirstHalfApril2023VehicleService.vehicle_service_id,
+};
+
+export const temporarySatFirstHalfApril2023VehicleJourneysByName = {
+  v1journey1: {
+    vehicle_journey_id: '34827909-ffe2-4e2e-a97d-d586dee6ea08',
+    block_id: temporarySatFirstHalfApril2023VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1journey2: {
+    vehicle_journey_id: '0a452996-b4ed-479f-9faf-e20b31294fe5',
+    block_id: temporarySatFirstHalfApril2023VehicleServiceBlock.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+};
+
+export const temporarySatFirstHalfApril2023Dataset: TableData<HslTimetablesDbTables>[] =
+  [
+    {
+      name: 'vehicle_schedule.vehicle_schedule_frame',
+      data: [temporarySatFirstHalfApril2023VehicleScheduleFrame],
+    },
+    {
+      name: 'vehicle_service.vehicle_service',
+      data: [temporarySatFirstHalfApril2023VehicleService],
+    },
+    {
+      name: 'vehicle_service.block',
+      data: [temporarySatFirstHalfApril2023VehicleServiceBlock],
+    },
+    {
+      name: 'vehicle_journey.vehicle_journey',
+      data: [
+        ...Object.values(temporarySatFirstHalfApril2023VehicleJourneysByName),
+      ],
+    },
+  ];

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/utils.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/utils.ts
@@ -1,0 +1,60 @@
+import { mergeLists } from '@util/schema';
+import { defaultHslTimetablesDbData } from '../defaultSetup';
+import { HslTimetablesDbTables } from '../schema';
+
+/**
+ * Gets the default timetable db data with given additions. Currently the this extends the default
+ * dataset with
+ * * Timetable dataset (which consists of vehicle_schedule_frames, vehicle_services,
+ *   vehicleServiceBlocks and vehicleJourneys, NOTE: when needed, this can be modified to also take in
+ *   passing_times)
+ * * Substitute operating day by line type datasets (which consists of substitute_operating_day_by_line_type )
+ *
+ * New additional datasets can be added to 'datasets/additional-sets'
+ */
+export const getDbDataWithAdditionalDatasets = ({
+  dbData = defaultHslTimetablesDbData,
+  datasets = [],
+}: // substituteOperatingDayByLineTypeDatasets = [],
+{
+  dbData?: TableData<HslTimetablesDbTables>[];
+  datasets?: TableData<HslTimetablesDbTables>[][];
+}) => {
+  const getDataByKey = (
+    data: TableData<HslTimetablesDbTables>[],
+    key: HslTimetablesDbTables,
+  ) => {
+    const dataByKey = data.find((item) => item.name === key);
+    return dataByKey ? dataByKey.data : [];
+  };
+
+  const getCombinedData = (
+    data: TableData<HslTimetablesDbTables>[][],
+    key: HslTimetablesDbTables,
+  ): TableData<HslTimetablesDbTables> => ({
+    name: key,
+    data: [
+      ...Object.values(getDataByKey(dbData, key)),
+      // For some reason flatMap() is not acceptable to typescript linter, so need to do .map().flat(1)..
+      ...data.map((item) => getDataByKey(item, key)).flat(1),
+    ],
+  });
+
+  const testData: TableData<HslTimetablesDbTables>[] = [
+    ...mergeLists(
+      dbData,
+      [
+        getCombinedData(datasets, 'vehicle_schedule.vehicle_schedule_frame'),
+        getCombinedData(datasets, 'vehicle_service.vehicle_service'),
+        getCombinedData(datasets, 'vehicle_service.block'),
+        getCombinedData(datasets, 'vehicle_journey.vehicle_journey'),
+        getCombinedData(
+          datasets,
+          'service_calendar.substitute_operating_day_by_line_type',
+        ),
+      ],
+      (tableSchema) => tableSchema.name,
+    ),
+  ];
+  return testData;
+};

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/index.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/index.ts
@@ -1,0 +1,3 @@
+export * from './substitute-operating-day-by-line-types';
+export * from './table-data';
+export * from './vehicle-schedule-frames';

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-day-by-line-types.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-day-by-line-types.ts
@@ -1,0 +1,14 @@
+import { TypeOfLine } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
+import { DayOfWeek, SubstituteOperatingDayByLineType } from '../types';
+
+export const substituteOperatingDayByLineTypes: SubstituteOperatingDayByLineType[] =
+  [
+    {
+      substitute_operating_day_by_line_type_id:
+        'd6965c0f-bc04-49fd-b21b-eed3a27de471',
+      type_of_line: TypeOfLine.StoppingBusService,
+      superseded_date: DateTime.fromISO('2023-01-01'),
+      substitute_day_of_week: DayOfWeek.Friday,
+    },
+  ];

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-day-by-line-types.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-day-by-line-types.ts
@@ -2,13 +2,15 @@ import { TypeOfLine } from 'generic/timetablesdb/datasets/types';
 import { DateTime } from 'luxon';
 import { DayOfWeek, SubstituteOperatingDayByLineType } from '../types';
 
+export const substituteOperatingDayByLineTypesByName = {
+  aprilFools: {
+    substitute_operating_day_by_line_type_id:
+      'd6965c0f-bc04-49fd-b21b-eed3a27de471',
+    type_of_line: TypeOfLine.StoppingBusService,
+    superseded_date: DateTime.fromISO('2023-04-01'),
+    substitute_day_of_week: DayOfWeek.Friday,
+  },
+};
+
 export const substituteOperatingDayByLineTypes: SubstituteOperatingDayByLineType[] =
-  [
-    {
-      substitute_operating_day_by_line_type_id:
-        'd6965c0f-bc04-49fd-b21b-eed3a27de471',
-      type_of_line: TypeOfLine.StoppingBusService,
-      superseded_date: DateTime.fromISO('2023-01-01'),
-      substitute_day_of_week: DayOfWeek.Friday,
-    },
-  ];
+  Object.values(substituteOperatingDayByLineTypesByName);

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/table-data.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/table-data.ts
@@ -1,0 +1,22 @@
+import { mergeLists } from '@util/schema';
+import { defaultGenericTimetablesDbData } from 'generic/timetablesdb/datasets/defaultSetup';
+import { HslTimetablesDbTables } from '../schema';
+import { substituteOperatingDayByLineTypes } from './substitute-operating-day-by-line-types';
+import { hslVehicleScheduleFrames } from './vehicle-schedule-frames';
+
+export const defaultHslTimetablesDbData: TableData<HslTimetablesDbTables>[] = [
+  ...mergeLists(
+    defaultGenericTimetablesDbData,
+    [
+      {
+        name: 'vehicle_schedule.vehicle_schedule_frame',
+        data: hslVehicleScheduleFrames,
+      },
+    ],
+    (tableSchema) => tableSchema.name,
+  ),
+  {
+    name: 'service_calendar.substitute_operating_day_by_line_type',
+    data: substituteOperatingDayByLineTypes,
+  },
+];

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/table-data.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/table-data.ts
@@ -2,7 +2,10 @@ import { mergeLists } from '@util/schema';
 import { defaultGenericTimetablesDbData } from 'generic/timetablesdb/datasets/defaultSetup';
 import { HslTimetablesDbTables } from '../schema';
 import { substituteOperatingDayByLineTypes } from './substitute-operating-day-by-line-types';
+import { hslVehicleJourneys } from './vehicle-journeys';
 import { hslVehicleScheduleFrames } from './vehicle-schedule-frames';
+import { hslVehicleServices } from './vehicle-services';
+import { hslVehicleServiceBlocks } from './vehicle-services-blocks';
 
 export const defaultHslTimetablesDbData: TableData<HslTimetablesDbTables>[] = [
   ...mergeLists(
@@ -12,6 +15,15 @@ export const defaultHslTimetablesDbData: TableData<HslTimetablesDbTables>[] = [
         name: 'vehicle_schedule.vehicle_schedule_frame',
         data: hslVehicleScheduleFrames,
       },
+      {
+        name: 'vehicle_service.vehicle_service',
+        data: hslVehicleServices,
+      },
+      {
+        name: 'vehicle_service.block',
+        data: hslVehicleServiceBlocks,
+      },
+      { name: 'vehicle_journey.vehicle_journey', data: hslVehicleJourneys },
     ],
     (tableSchema) => tableSchema.name,
   ),

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-journeys.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-journeys.ts
@@ -1,0 +1,51 @@
+import {
+  journeyPatternRefsByName,
+  vehicleJourneys,
+  vehicleServiceBlocksByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { VehicleJourney } from 'generic/timetablesdb/datasets/types';
+import { hslVehicleServiceBlocksByName } from './vehicle-services-blocks';
+
+export const hslVehicleJourneysByName = {
+  v1SatJourney1: {
+    vehicle_journey_id: 'fb56601c-7ac5-4369-bf26-c7f0d3a00b92',
+    block_id: vehicleServiceBlocksByName.v1Sat.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1SatJourney2: {
+    vehicle_journey_id: '9bdac86c-f7a0-46ac-9d79-65ac9907c4bb',
+    block_id: vehicleServiceBlocksByName.v1Sat.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+  v1SunJourney1: {
+    vehicle_journey_id: '40690cb5-dadd-46bd-9f44-62ca072e902c',
+    block_id: vehicleServiceBlocksByName.v1Sun.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1SunJourney2: {
+    vehicle_journey_id: '1c71002e-25b6-47b9-b90c-42c868ddb7c8',
+    block_id: vehicleServiceBlocksByName.v1Sun.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+  v1AscensionDayJourney1: {
+    vehicle_journey_id: 'feb60181-3313-43a7-bdae-07508e2cebca',
+    block_id: hslVehicleServiceBlocksByName.v1Ascension.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Inbound.journey_pattern_ref_id,
+  },
+  v1AscensionDayJourney2: {
+    vehicle_journey_id: '9947bacd-353b-4489-84e8-26492b69b8b6',
+    block_id: hslVehicleServiceBlocksByName.v1Ascension.block_id,
+    journey_pattern_ref_id:
+      journeyPatternRefsByName.route123Outbound.journey_pattern_ref_id,
+  },
+};
+
+// TODO: Add actual conversion to hsl model when needed
+export const hslVehicleJourneys: VehicleJourney[] = vehicleJourneys.concat(
+  Object.values(hslVehicleJourneysByName),
+);

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-schedule-frames.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-schedule-frames.ts
@@ -1,0 +1,6 @@
+import { vehicleScheduleFrames } from 'generic/timetablesdb/datasets/defaultSetup';
+import { buildHslVehicleScheduleFrame } from '../factories';
+import { HslVehicleScheduleFrame } from '../types';
+
+export const hslVehicleScheduleFrames: HslVehicleScheduleFrame[] =
+  vehicleScheduleFrames.map(buildHslVehicleScheduleFrame);

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-schedule-frames.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-schedule-frames.ts
@@ -1,6 +1,21 @@
 import { vehicleScheduleFrames } from 'generic/timetablesdb/datasets/defaultSetup';
+import { TimetablePriority } from 'generic/timetablesdb/datasets/types';
+import { DateTime } from 'luxon';
 import { buildHslVehicleScheduleFrame } from '../factories';
 import { HslVehicleScheduleFrame } from '../types';
 
+export const hslVehicleScheduleFramesByName = {
+  specialAscensionDay2023: buildHslVehicleScheduleFrame({
+    vehicle_schedule_frame_id: '52c5afdb-9a04-4aed-8769-4bdb761aa6f6',
+    validity_start: DateTime.fromISO('2023-05-18'),
+    validity_end: DateTime.fromISO('2023-05-18'),
+    priority: TimetablePriority.Special,
+    name: 'Helatorstai 2023',
+    created_at: DateTime.fromISO('2022-02-01T02:34:56.789+02:00'),
+  }),
+};
+
 export const hslVehicleScheduleFrames: HslVehicleScheduleFrame[] =
-  vehicleScheduleFrames.map(buildHslVehicleScheduleFrame);
+  vehicleScheduleFrames
+    .map(buildHslVehicleScheduleFrame)
+    .concat(Object.values(hslVehicleScheduleFramesByName));

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-services-blocks.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-services-blocks.ts
@@ -1,0 +1,15 @@
+import { vehicleServiceBlocks } from 'generic/timetablesdb/datasets/defaultSetup';
+import { VehicleServiceBlock } from 'generic/timetablesdb/datasets/types';
+import { hslVehicleServicesByName } from './vehicle-services';
+
+export const hslVehicleServiceBlocksByName = {
+  // Vehicle 1 Ascension day
+  v1Ascension: {
+    block_id: 'd911c6eb-35c1-4bd5-9268-6daf3d52ed55',
+    vehicle_service_id: hslVehicleServicesByName.v1Ascension.vehicle_service_id,
+  },
+};
+
+// TODO: Add actual conversion to hsl model when needed
+export const hslVehicleServiceBlocks: VehicleServiceBlock[] =
+  vehicleServiceBlocks.concat(Object.values(hslVehicleServiceBlocksByName));

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-services.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/vehicle-services.ts
@@ -1,0 +1,22 @@
+import {
+  defaultDayTypeIds,
+  vehicleServices,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import { VehicleService } from 'generic/timetablesdb/datasets/types';
+import { hslVehicleScheduleFramesByName } from './vehicle-schedule-frames';
+
+export const hslVehicleServicesByName = {
+  // vehicle 1, Ascension day
+  v1Ascension: {
+    vehicle_service_id: 'c2eb46b8-2702-433f-9647-9694a62943c0',
+    day_type_id: defaultDayTypeIds.THURSDAY,
+    vehicle_schedule_frame_id:
+      hslVehicleScheduleFramesByName.specialAscensionDay2023
+        .vehicle_schedule_frame_id,
+  },
+};
+
+// TODO: Add more precise conversion to hsl model when needed
+export const hslVehicleServices: VehicleService[] = vehicleServices.concat(
+  Object.values(hslVehicleServicesByName),
+);

--- a/test/hasura/hsl/timetablesdb/datasets/factories.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/factories.ts
@@ -1,0 +1,22 @@
+/* eslint-disable camelcase */
+import {
+  buildName,
+  buildVehicleScheduleFrame,
+} from 'generic/timetablesdb/datasets/factories';
+import { VehicleScheduleFrame } from 'generic/timetablesdb/datasets/types';
+import { HslVehicleScheduleFrame } from './types';
+
+type VehicleScheduleFrameParams = Parameters<
+  typeof buildVehicleScheduleFrame
+>[0];
+
+export const buildHslVehicleScheduleFrame = (
+  input: VehicleScheduleFrameParams & Partial<HslVehicleScheduleFrame>,
+): HslVehicleScheduleFrame => {
+  const { booking_label, booking_description_i18n, ...rest } = input;
+  return {
+    ...buildVehicleScheduleFrame(rest as VehicleScheduleFrame),
+    booking_label: booking_label || buildName(input).fi_FI,
+    booking_description_i18n,
+  };
+};

--- a/test/hasura/hsl/timetablesdb/datasets/factories.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/factories.ts
@@ -3,19 +3,18 @@ import {
   buildName,
   buildVehicleScheduleFrame,
 } from 'generic/timetablesdb/datasets/factories';
-import { VehicleScheduleFrame } from 'generic/timetablesdb/datasets/types';
 import { HslVehicleScheduleFrame } from './types';
 
-type VehicleScheduleFrameParams = Parameters<
+type BuildVehicleScheduleFrameParams = Parameters<
   typeof buildVehicleScheduleFrame
 >[0];
 
 export const buildHslVehicleScheduleFrame = (
-  input: VehicleScheduleFrameParams & Partial<HslVehicleScheduleFrame>,
+  input: BuildVehicleScheduleFrameParams & Partial<HslVehicleScheduleFrame>,
 ): HslVehicleScheduleFrame => {
   const { booking_label, booking_description_i18n, ...rest } = input;
   return {
-    ...buildVehicleScheduleFrame(rest as VehicleScheduleFrame),
+    ...buildVehicleScheduleFrame(rest),
     booking_label: booking_label || buildName(input).fi_FI,
     booking_description_i18n,
   };

--- a/test/hasura/hsl/timetablesdb/datasets/schema.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/schema.ts
@@ -1,0 +1,19 @@
+import {
+  genericTimetablesDbSchema,
+  genericTimetablesDbTables,
+} from 'generic/timetablesdb/datasets/schema';
+import { substituteOperatingDayByLineTypeProps } from './types';
+
+export const hslTimetablesDbTables = [
+  ...genericTimetablesDbTables,
+  'service_calendar.substitute_operating_day_by_line_type',
+] as const;
+export type HslTimetablesDbTables = (typeof hslTimetablesDbTables)[number];
+
+export const hslTimetablesDbSchema: TableSchemaMap<HslTimetablesDbTables> = {
+  ...genericTimetablesDbSchema,
+  'service_calendar.substitute_operating_day_by_line_type': {
+    name: 'service_calendar.substitute_operating_day_by_line_type',
+    props: substituteOperatingDayByLineTypeProps,
+  },
+};

--- a/test/hasura/hsl/timetablesdb/datasets/types.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/types.ts
@@ -1,8 +1,9 @@
 import {
+  TimetablePriority,
   TypeOfLine,
   VehicleScheduleFrame,
 } from 'generic/timetablesdb/datasets/types';
-import { DateTime, Interval } from 'luxon';
+import { DateTime, Duration } from 'luxon';
 
 export type HslVehicleScheduleFrame = VehicleScheduleFrame & {
   booking_label: string;
@@ -31,15 +32,24 @@ export const substituteOperatingDayByLineTypeProps: Property[] = [
   'end_datetime',
 ];
 
-// TODO: Check the correct types for times
 export type SubstituteOperatingDayByLineType = {
   substitute_operating_day_by_line_type_id: UUID;
   type_of_line: TypeOfLine;
   superseded_date: DateTime;
-  substitute_day_of_week?: DayOfWeek;
-  begin_time?: Interval;
-  end_time?: Interval;
+  substitute_day_of_week?: DayOfWeek | null;
+  begin_time?: Duration | null;
+  end_time?: Duration | null;
   timezone?: string;
   begin_datetime?: DateTime;
   end_datetime?: DateTime;
+};
+
+export type TimetableVersion = {
+  vehicle_schedule_frame_id: UUID | null;
+  substitute_operating_day_by_line_type_id: UUID | null;
+  in_effect: boolean;
+  priority: TimetablePriority;
+  day_type_id: UUID;
+  validity_start: DateTime;
+  validity_end: DateTime;
 };

--- a/test/hasura/hsl/timetablesdb/datasets/types.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/types.ts
@@ -1,0 +1,45 @@
+import {
+  TypeOfLine,
+  VehicleScheduleFrame,
+} from 'generic/timetablesdb/datasets/types';
+import { DateTime, Interval } from 'luxon';
+
+export type HslVehicleScheduleFrame = VehicleScheduleFrame & {
+  booking_label: string;
+  booking_description_i18n?: LocalizedString;
+};
+
+export enum DayOfWeek {
+  Monday = 1,
+  Tuesday = 2,
+  Wednesday = 3,
+  Thursday = 4,
+  Friday = 5,
+  Saturday = 6,
+  Sunday = 7,
+}
+
+export const substituteOperatingDayByLineTypeProps: Property[] = [
+  'substitute_operating_day_by_line_type_id',
+  'type_of_line',
+  'superseded_date',
+  'substitute_day_of_week',
+  'begin_time',
+  'end_time',
+  'timezone',
+  'begin_datetime',
+  'end_datetime',
+];
+
+// TODO: Check the correct types for times
+export type SubstituteOperatingDayByLineType = {
+  substitute_operating_day_by_line_type_id: UUID;
+  type_of_line: TypeOfLine;
+  superseded_date: DateTime;
+  substitute_day_of_week?: DayOfWeek;
+  begin_time?: Interval;
+  end_time?: Interval;
+  timezone?: string;
+  begin_datetime?: DateTime;
+  end_datetime?: DateTime;
+};

--- a/test/hasura/hsl/timetablesdb/integration-tests/function-get-timetable-versions-by-journey-pattern-ids/get-timetable-versions-by-journey-pattern-ids.spec.ts
+++ b/test/hasura/hsl/timetablesdb/integration-tests/function-get-timetable-versions-by-journey-pattern-ids/get-timetable-versions-by-journey-pattern-ids.spec.ts
@@ -580,6 +580,162 @@ describe('function get_timetable_versions_by_journey_pattern_ids', () => {
     });
   });
 
+  describe('more than one journey pattern', () => {
+    describe('time range hits timetables on both journey patterns timetables (winter and summer)', () => {
+      describe('observation date is on summer timetables validity range', () => {
+        it('should have only the summer timetable version in effect', async () => {
+          const startDate = DateTime.fromISO('2023-01-01');
+          const endDate = DateTime.fromISO('2023-06-30');
+          const observationDate = DateTime.fromISO('2023-06-01');
+
+          const response = await getTimetableVersions(
+            defaultHslTimetablesDbData,
+            [
+              journeyPatternRefsByName.route123Inbound.journey_pattern_id,
+              journeyPatternRefsByName.route234Outbound.journey_pattern_id,
+            ],
+            startDate,
+            endDate,
+            observationDate,
+          );
+          const mappedResponse = mapTimetableVersionResponse(response);
+
+          expect(
+            // Sort arrays so that the order does not matter
+            sortVersionsForAssert(mappedResponse),
+          ).toEqual(
+            sortVersionsForAssert([
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.winter2022
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.SUNDAY,
+                in_effect: false,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.winter2022
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+                in_effect: false,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.winter2022
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.SATURDAY,
+                in_effect: false,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  hslVehicleScheduleFramesByName.specialAscensionDay2023
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.THURSDAY,
+                in_effect: false,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.summer2023
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+                in_effect: true,
+              },
+              {
+                day_type_id: defaultDayTypeIds.SATURDAY,
+                in_effect: false,
+                substitute_operating_day_by_line_type_id:
+                  substituteOperatingDayByLineTypesByName.aprilFools
+                    .substitute_operating_day_by_line_type_id,
+                vehicle_schedule_frame_id: null,
+              },
+            ]),
+          );
+        });
+      });
+
+      describe('observation date is on winter timetables validity range', () => {
+        it('should have only the winter timetable version in effect', async () => {
+          const startDate = DateTime.fromISO('2023-01-01');
+          const endDate = DateTime.fromISO('2023-06-30');
+          const observationDate = DateTime.fromISO('2023-01-30');
+
+          const response = await getTimetableVersions(
+            defaultHslTimetablesDbData,
+            [
+              journeyPatternRefsByName.route123Inbound.journey_pattern_id,
+              journeyPatternRefsByName.route234Outbound.journey_pattern_id,
+            ],
+            startDate,
+            endDate,
+            observationDate,
+          );
+          const mappedResponse = mapTimetableVersionResponse(response);
+
+          expect(
+            // Sort arrays so that the order does not matter
+            sortVersionsForAssert(mappedResponse),
+          ).toEqual(
+            sortVersionsForAssert([
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.winter2022
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.SUNDAY,
+                in_effect: true,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.winter2022
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+                in_effect: true,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.winter2022
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.SATURDAY,
+                in_effect: true,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  hslVehicleScheduleFramesByName.specialAscensionDay2023
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.THURSDAY,
+                in_effect: false,
+              },
+              {
+                vehicle_schedule_frame_id:
+                  vehicleScheduleFramesByName.summer2023
+                    .vehicle_schedule_frame_id,
+                substitute_operating_day_by_line_type_id: null,
+                day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+                in_effect: false,
+              },
+              {
+                day_type_id: defaultDayTypeIds.SATURDAY,
+                in_effect: false,
+                substitute_operating_day_by_line_type_id:
+                  substituteOperatingDayByLineTypesByName.aprilFools
+                    .substitute_operating_day_by_line_type_id,
+                vehicle_schedule_frame_id: null,
+              },
+            ]),
+          );
+        });
+      });
+    });
+  });
+
   describe('draft and staging priorities', () => {
     it('should not be affected by draft priority (Standard priorities should be in effect)', async () => {
       const startDate = DateTime.fromISO('2023-04-01');

--- a/test/hasura/hsl/timetablesdb/integration-tests/function-get-timetable-versions-by-journey-pattern-ids/get-timetable-versions-by-journey-pattern-ids.spec.ts
+++ b/test/hasura/hsl/timetablesdb/integration-tests/function-get-timetable-versions-by-journey-pattern-ids/get-timetable-versions-by-journey-pattern-ids.spec.ts
@@ -1,0 +1,692 @@
+import * as config from '@config';
+import * as db from '@util/db';
+import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
+import { setupDb } from '@util/setup';
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+  vehicleScheduleFramesByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import {
+  draftSunApril2023Dataset,
+  draftSunApril2023VehicleScheduleFrame,
+  draftSunApril2024Dataset,
+  draftSunApril2024VehicleScheduleFrame,
+  expressBusServiceSaturday20230520Dataset,
+  getDbDataWithAdditionalDatasets,
+  specialAprilFools2023Dataset,
+  specialAprilFools2023VehicleScheduleFrame,
+  stagingSunApril2024Dataset,
+  temporarySatFirstHalfApril2023Dataset,
+  temporarySatFirstHalfApril2023VehicleScheduleFrame,
+} from 'hsl/timetablesdb/datasets/additional-sets';
+import {
+  defaultHslTimetablesDbData,
+  hslVehicleScheduleFramesByName,
+  substituteOperatingDayByLineTypesByName,
+} from 'hsl/timetablesdb/datasets/defaultSetup';
+import { HslTimetablesDbTables } from 'hsl/timetablesdb/datasets/schema';
+import { TimetableVersion } from 'hsl/timetablesdb/datasets/types';
+import {
+  mapTimetableVersionResponse,
+  sortVersionsForAssert,
+} from 'hsl/timetablesdb/test-utils';
+import { DateTime } from 'luxon';
+
+describe('function get_timetable_versions_by_journey_pattern_ids', () => {
+  let dbConnection: DbConnection;
+
+  beforeAll(() => {
+    dbConnection = createDbConnection(config.timetablesDbConfig);
+  });
+
+  afterAll(() => closeDbConnection(dbConnection));
+
+  const getTimetableVersions = async (
+    dataset: TableData<HslTimetablesDbTables>[],
+    journeyPatternIds: string[],
+    startDate: DateTime,
+    endDate: DateTime,
+    observationDate: DateTime,
+  ): Promise<Array<TimetableVersion>> => {
+    await setupDb(dbConnection, dataset);
+    const response = await db.singleQuery(
+      dbConnection,
+      `SELECT * FROM vehicle_service.get_timetable_versions_by_journey_pattern_ids(
+        '{${journeyPatternIds}}'::uuid[],
+        '${startDate.toISODate()}'::date,
+        '${endDate.toISODate()}'::date,
+        '${observationDate.toISODate()}'::date
+      )`,
+    );
+
+    return response.rows;
+  };
+
+  it('should have empty result from a timerange where no timetables are valid', async () => {
+    const startDate = DateTime.fromISO('2021-01-01');
+    const endDate = DateTime.fromISO('2021-06-30');
+    const observationDate = DateTime.fromISO('2021-05-01');
+
+    const response = await getTimetableVersions(
+      defaultHslTimetablesDbData,
+      [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+      startDate,
+      endDate,
+      observationDate,
+    );
+
+    expect(response.length).toBe(0);
+  });
+
+  describe('dataset has priorities: standard (Mon-Fri, Sat, Sun), temporary and substitute operating day by line type (Sat)', () => {
+    describe('only standard priority is valid on observation date', () => {
+      it(`should have only the standard priority versions in effect`, async () => {
+        const startDate = DateTime.fromISO('2023-04-01');
+        const endDate = DateTime.fromISO('2023-04-30');
+        const observationDate = DateTime.fromISO('2023-04-16');
+
+        const response = await getTimetableVersions(
+          getDbDataWithAdditionalDatasets({
+            datasets: [temporarySatFirstHalfApril2023Dataset],
+          }),
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                temporarySatFirstHalfApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id: null,
+              substitute_operating_day_by_line_type_id:
+                substituteOperatingDayByLineTypesByName.aprilFools
+                  .substitute_operating_day_by_line_type_id,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+          ]),
+        );
+      });
+    });
+
+    describe('standard and temporary priority are valid on observation date', () => {
+      it(`should have temporary priority in effect (Saturday)`, async () => {
+        const startDate = DateTime.fromISO('2023-04-01');
+        const endDate = DateTime.fromISO('2023-04-30');
+        const observationDate = DateTime.fromISO('2023-04-14');
+
+        const response = await getTimetableVersions(
+          getDbDataWithAdditionalDatasets({
+            datasets: [temporarySatFirstHalfApril2023Dataset],
+          }),
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id:
+                temporarySatFirstHalfApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id: null,
+              substitute_operating_day_by_line_type_id:
+                substituteOperatingDayByLineTypesByName.aprilFools
+                  .substitute_operating_day_by_line_type_id,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+          ]),
+        );
+      });
+    });
+
+    describe('standard, temporary and substitute by line type priority are valid on observation date', () => {
+      it(`should have substitute day by line type priority in effect (Saturday)`, async () => {
+        const startDate = DateTime.fromISO('2023-04-01');
+        const endDate = DateTime.fromISO('2023-04-30');
+        const observationDate = DateTime.fromISO('2023-04-01');
+
+        const response = await getTimetableVersions(
+          getDbDataWithAdditionalDatasets({
+            datasets: [temporarySatFirstHalfApril2023Dataset],
+          }),
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id:
+                temporarySatFirstHalfApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id: null,
+              substitute_operating_day_by_line_type_id:
+                substituteOperatingDayByLineTypesByName.aprilFools
+                  .substitute_operating_day_by_line_type_id,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('dataset has priorities: standard (Mon-Fri, Sat, Sun), temporary, substitute operating day by line type and special (Sat)', () => {
+    describe('standard, temporary and substitute by line type and special priority are valid on observation date', () => {
+      it(`should have special priority in effect (Saturday)`, async () => {
+        const startDate = DateTime.fromISO('2023-04-01');
+        const endDate = DateTime.fromISO('2023-04-30');
+        const observationDate = DateTime.fromISO('2023-04-01');
+
+        const response = await getTimetableVersions(
+          getDbDataWithAdditionalDatasets({
+            datasets: [
+              temporarySatFirstHalfApril2023Dataset,
+              specialAprilFools2023Dataset,
+            ],
+          }),
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id:
+                temporarySatFirstHalfApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id: null,
+              substitute_operating_day_by_line_type_id:
+                substituteOperatingDayByLineTypesByName.aprilFools
+                  .substitute_operating_day_by_line_type_id,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id:
+                specialAprilFools2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('dataset has standard priorities (Mon-Fri, Sat, Sun) and special day (Thu)', () => {
+    describe('standard priorities and special priority are valid on observation date', () => {
+      it('should have ALL standard priorities AND special day in effect (not 1:1 overlap on day type)', async () => {
+        const startDate = DateTime.fromISO('2023-05-01');
+        const endDate = DateTime.fromISO('2023-05-31');
+        const observationDate = DateTime.fromISO('2023-05-18');
+
+        const response = await getTimetableVersions(
+          defaultHslTimetablesDbData,
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                hslVehicleScheduleFramesByName.specialAscensionDay2023
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.THURSDAY,
+              in_effect: true,
+            },
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('dataset has substitute operating day for a different type of line (Express bus)', () => {
+    describe('substitute operating day would be valid on observation date', () => {
+      it('should not include or be affected by the different type of line (Express bus) substitute operating day', async () => {
+        const startDate = DateTime.fromISO('2023-05-01');
+        const endDate = DateTime.fromISO('2023-05-31');
+        const observationDate = DateTime.fromISO('2023-05-20');
+
+        const response = await getTimetableVersions(
+          getDbDataWithAdditionalDatasets({
+            datasets: [expressBusServiceSaturday20230520Dataset],
+          }),
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                hslVehicleScheduleFramesByName.specialAscensionDay2023
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.THURSDAY,
+              in_effect: false,
+            },
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('dataset has standard priorities (Mon-Fri, Sat, Sun)', () => {
+    describe('observation date is out of startDate - endDate range and also out of vehicle_schedule_frame validity range', () => {
+      it('should return rows but nothing should be in effect', async () => {
+        const startDate = DateTime.fromISO('2023-01-01');
+        const endDate = DateTime.fromISO('2023-01-31');
+        const observationDate = DateTime.fromISO('2021-01-01');
+
+        const response = await getTimetableVersions(
+          defaultHslTimetablesDbData,
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: false,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: false,
+            },
+          ]),
+        );
+      });
+    });
+
+    describe('observation date is out of startDate - endDate range but inside vehicle_schedule_frame validity range', () => {
+      it('should return rows that are in effect on observation date and valid on observation date and the time range', async () => {
+        const startDate = DateTime.fromISO('2023-02-01');
+        const endDate = DateTime.fromISO('2023-02-28');
+        const observationDate = DateTime.fromISO('2023-01-01');
+
+        const response = await getTimetableVersions(
+          defaultHslTimetablesDbData,
+          [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+          startDate,
+          endDate,
+          observationDate,
+        );
+
+        const mappedResponse = mapTimetableVersionResponse(response);
+
+        expect(
+          // Sort arrays so that the order does not matter
+          sortVersionsForAssert(mappedResponse),
+        ).toEqual(
+          sortVersionsForAssert([
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SATURDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.SUNDAY,
+              in_effect: true,
+            },
+            {
+              vehicle_schedule_frame_id:
+                vehicleScheduleFramesByName.winter2022
+                  .vehicle_schedule_frame_id,
+              substitute_operating_day_by_line_type_id: null,
+              day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+              in_effect: true,
+            },
+          ]),
+        );
+      });
+    });
+  });
+
+  describe('draft and staging priorities', () => {
+    it('should not be affected by draft priority (Standard priorities should be in effect)', async () => {
+      const startDate = DateTime.fromISO('2023-04-01');
+      const endDate = DateTime.fromISO('2023-04-30');
+      const observationDate = DateTime.fromISO('2023-04-10');
+
+      const response = await getTimetableVersions(
+        getDbDataWithAdditionalDatasets({
+          datasets: [draftSunApril2023Dataset],
+        }),
+        [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+        startDate,
+        endDate,
+        observationDate,
+      );
+
+      const mappedResponse = mapTimetableVersionResponse(response);
+
+      expect(
+        // Sort arrays so that the order does not matter
+        sortVersionsForAssert(mappedResponse),
+      ).toEqual(
+        sortVersionsForAssert([
+          {
+            vehicle_schedule_frame_id: null,
+            substitute_operating_day_by_line_type_id:
+              substituteOperatingDayByLineTypesByName.aprilFools
+                .substitute_operating_day_by_line_type_id,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SUNDAY,
+            in_effect: true,
+          },
+          {
+            vehicle_schedule_frame_id:
+              vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+            in_effect: true,
+          },
+          {
+            vehicle_schedule_frame_id:
+              vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: true,
+          },
+          {
+            vehicle_schedule_frame_id:
+              draftSunApril2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SUNDAY,
+            in_effect: false,
+          },
+        ]),
+      );
+    });
+
+    it('should not have draft in effect, even if it is the only valid version', async () => {
+      const startDate = DateTime.fromISO('2024-04-01');
+      const endDate = DateTime.fromISO('2024-04-30');
+      const observationDate = DateTime.fromISO('2024-04-10');
+
+      const response = await getTimetableVersions(
+        getDbDataWithAdditionalDatasets({
+          datasets: [draftSunApril2024Dataset],
+        }),
+        [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+        startDate,
+        endDate,
+        observationDate,
+      );
+
+      const mappedResponse = mapTimetableVersionResponse(response);
+
+      expect(mappedResponse).toEqual([
+        {
+          vehicle_schedule_frame_id:
+            draftSunApril2024VehicleScheduleFrame.vehicle_schedule_frame_id,
+          substitute_operating_day_by_line_type_id: null,
+          day_type_id: defaultDayTypeIds.SUNDAY,
+          in_effect: false,
+        },
+      ]);
+    });
+
+    it('should not return staging priorities at all', async () => {
+      const startDate = DateTime.fromISO('2024-04-01');
+      const endDate = DateTime.fromISO('2024-04-30');
+      const observationDate = DateTime.fromISO('2024-04-10');
+
+      const response = await getTimetableVersions(
+        getDbDataWithAdditionalDatasets({
+          datasets: [stagingSunApril2024Dataset],
+        }),
+        [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+        startDate,
+        endDate,
+        observationDate,
+      );
+
+      expect(response.length).toBe(0);
+    });
+  });
+});

--- a/test/hasura/hsl/timetablesdb/integration-tests/function-get_timetables_and_substitute_operating_days/get-timetables-and-substitute-operating-days.spec.ts
+++ b/test/hasura/hsl/timetablesdb/integration-tests/function-get_timetables_and_substitute_operating_days/get-timetables-and-substitute-operating-days.spec.ts
@@ -1,0 +1,196 @@
+import * as config from '@config';
+import * as db from '@util/db';
+import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
+import { setupDb } from '@util/setup';
+import {
+  defaultDayTypeIds,
+  journeyPatternRefsByName,
+  vehicleScheduleFramesByName,
+} from 'generic/timetablesdb/datasets/defaultSetup';
+import {
+  draftSunApril2024Dataset,
+  draftSunApril2024VehicleScheduleFrame,
+  expressBusServiceSaturday20230520Dataset,
+  getDbDataWithAdditionalDatasets,
+  stoppingBusServiceSaturday20230520Dataset,
+  stoppingBusServiceSaturday20230520SubstituteOperatingDayByLineType,
+  temporarySatFirstHalfApril2023Dataset,
+  temporarySatFirstHalfApril2023VehicleService,
+} from 'hsl/timetablesdb/datasets/additional-sets';
+import {
+  specialAprilFools2023Dataset,
+  specialAprilFools2023VehicleScheduleFrame,
+} from 'hsl/timetablesdb/datasets/additional-sets/timetables/specialAprilFools2023Dataset';
+import { stagingSunApril2024Dataset } from 'hsl/timetablesdb/datasets/additional-sets/timetables/stagingSunApril2024Dataset';
+import {
+  hslVehicleScheduleFramesByName,
+  substituteOperatingDayByLineTypesByName,
+} from 'hsl/timetablesdb/datasets/defaultSetup';
+import { HslTimetablesDbTables } from 'hsl/timetablesdb/datasets/schema';
+import { TimetableVersion } from 'hsl/timetablesdb/datasets/types';
+import {
+  mapTimetableVersionResponse,
+  sortVersionsForAssert,
+} from 'hsl/timetablesdb/test-utils';
+import { DateTime } from 'luxon';
+
+describe('Function get_timetables_and_substitute_operating_days', () => {
+  let dbConnection: DbConnection;
+
+  beforeAll(() => {
+    dbConnection = createDbConnection(config.timetablesDbConfig);
+  });
+
+  afterAll(() => closeDbConnection(dbConnection));
+
+  const getTimetablesAndSubstituteOperatingDays = async (
+    dataset: TableData<HslTimetablesDbTables>[],
+    journeyPatternIds: string[],
+    startDate: DateTime,
+    endDate: DateTime,
+  ): Promise<Array<TimetableVersion>> => {
+    await setupDb(dbConnection, dataset);
+    const response = await db.singleQuery(
+      dbConnection,
+      `SELECT * FROM vehicle_service.get_timetables_and_substitute_operating_days('
+        {${journeyPatternIds}}'::uuid[],
+        '${startDate.toISODate()}'::date,
+        '${endDate.toISODate()}'::date
+      )`,
+    );
+
+    return response.rows;
+  };
+
+  describe('dataset has priorities: standard, temporary, substitute by line type (express bus and stopping bus service) and special', () => {
+    it('should return rows for everything else but express bus substitute operating day by line type', async () => {
+      const startDate = DateTime.fromISO('2023-01-01');
+      const endDate = DateTime.fromISO('2023-12-31');
+      const response = await getTimetablesAndSubstituteOperatingDays(
+        getDbDataWithAdditionalDatasets({
+          datasets: [
+            specialAprilFools2023Dataset,
+            temporarySatFirstHalfApril2023Dataset,
+            expressBusServiceSaturday20230520Dataset,
+            stoppingBusServiceSaturday20230520Dataset,
+          ],
+        }),
+        [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+        startDate,
+        endDate,
+      );
+
+      const mappedResponse = mapTimetableVersionResponse(response);
+
+      expect(
+        // Sort arrays so that the order does not matter
+        sortVersionsForAssert(mappedResponse),
+      ).toEqual(
+        sortVersionsForAssert([
+          {
+            vehicle_schedule_frame_id: null,
+            substitute_operating_day_by_line_type_id:
+              stoppingBusServiceSaturday20230520SubstituteOperatingDayByLineType.substitute_operating_day_by_line_type_id,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id: null,
+            substitute_operating_day_by_line_type_id:
+              substituteOperatingDayByLineTypesByName.aprilFools
+                .substitute_operating_day_by_line_type_id,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SUNDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              vehicleScheduleFramesByName.winter2022.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.MONDAY_FRIDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              hslVehicleScheduleFramesByName.specialAscensionDay2023
+                .vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.THURSDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              temporarySatFirstHalfApril2023VehicleService.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: false,
+          },
+          {
+            vehicle_schedule_frame_id:
+              specialAprilFools2023VehicleScheduleFrame.vehicle_schedule_frame_id,
+            substitute_operating_day_by_line_type_id: null,
+            day_type_id: defaultDayTypeIds.SATURDAY,
+            in_effect: false,
+          },
+        ]),
+      );
+    });
+  });
+
+  describe('draft and staging priorities', () => {
+    it('should return rows for draft priorities', async () => {
+      const startDate = DateTime.fromISO('2024-04-01');
+      const endDate = DateTime.fromISO('2024-04-30');
+
+      const response = await getTimetablesAndSubstituteOperatingDays(
+        getDbDataWithAdditionalDatasets({
+          datasets: [draftSunApril2024Dataset],
+        }),
+        [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+        startDate,
+        endDate,
+      );
+
+      const mappedResponse = mapTimetableVersionResponse(response);
+
+      expect(mappedResponse).toEqual([
+        {
+          vehicle_schedule_frame_id:
+            draftSunApril2024VehicleScheduleFrame.vehicle_schedule_frame_id,
+          substitute_operating_day_by_line_type_id: null,
+          day_type_id: defaultDayTypeIds.SUNDAY,
+          in_effect: false,
+        },
+      ]);
+    });
+
+    it('should not return rows for staging priorities', async () => {
+      const startDate = DateTime.fromISO('2024-04-01');
+      const endDate = DateTime.fromISO('2024-04-30');
+
+      const response = await getTimetablesAndSubstituteOperatingDays(
+        getDbDataWithAdditionalDatasets({
+          datasets: [stagingSunApril2024Dataset],
+        }),
+        [journeyPatternRefsByName.route123Inbound.journey_pattern_id],
+        startDate,
+        endDate,
+      );
+
+      expect(response.length).toBe(0);
+    });
+  });
+});

--- a/test/hasura/hsl/timetablesdb/integration-tests/hsl-timetables-db-default-dataset-insertion.spec.ts
+++ b/test/hasura/hsl/timetablesdb/integration-tests/hsl-timetables-db-default-dataset-insertion.spec.ts
@@ -1,0 +1,26 @@
+import * as config from '@config';
+import * as db from '@util/db';
+import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
+import { setupDb } from '@util/setup';
+import { defaultHslTimetablesDbData } from 'hsl/timetablesdb/datasets/defaultSetup';
+
+describe('Inserting hsl timetables specific data', () => {
+  let dbConnection: DbConnection;
+
+  beforeAll(() => {
+    dbConnection = createDbConnection(config.timetablesDbConfig);
+  });
+
+  afterAll(() => closeDbConnection(dbConnection));
+
+  it('should insert defaultHslTimetablesDbData succesfully and fetch data from hsl timetables specific table', async () => {
+    await setupDb(dbConnection, defaultHslTimetablesDbData);
+
+    const response = await db.singleQuery(
+      dbConnection,
+      `SELECT * FROM service_calendar.substitute_operating_day_by_line_type`,
+    );
+
+    expect(response.rows.length).toBeGreaterThan(0);
+  });
+});

--- a/test/hasura/hsl/timetablesdb/test-utils.ts
+++ b/test/hasura/hsl/timetablesdb/test-utils.ts
@@ -1,0 +1,37 @@
+import { sortBy } from 'lodash';
+import { TimetableVersion } from './datasets/types';
+
+/**
+ * This function can be used to sort the response and the expected result lists in to
+ * the same order, so we can ignore the order of the response and developer doesn't need
+ * to care in what order the response list comes in.
+ *
+ * Example use:
+ * expect(sortVersionsForAssert(response)).toEqual(sortVersionsForAssert(expectedResult));
+ */
+export const sortVersionsForAssert = (
+  data: {
+    vehicle_schedule_frame_id: UUID | null;
+    day_type_id: UUID;
+    in_effect: boolean;
+    substitute_operating_day_by_line_type_id: UUID | null;
+  }[],
+) =>
+  sortBy(data, [
+    'vehicle_schedule_frame_id',
+    'day_type_id',
+    'in_effect',
+    'substitute_operating_day_by_line_type_id',
+  ]);
+
+/**
+ * Extracts and maps only the test relevant information from the response.
+ */
+export const mapTimetableVersionResponse = (response: TimetableVersion[]) =>
+  response.map((version) => ({
+    vehicle_schedule_frame_id: version.vehicle_schedule_frame_id,
+    substitute_operating_day_by_line_type_id:
+      version.substitute_operating_day_by_line_type_id,
+    day_type_id: version.day_type_id,
+    in_effect: version.in_effect,
+  }));


### PR DESCRIPTION
2 commits:
**Add hsl timetables test infra**
We already have generic - network, generic - timetables and hsl - network
infra created. This commit will bring the base for hsl - timetables test infra.

Resolves https://github.com/HSLdevcom/jore4/issues/1275

**Add additional datasets and timetable version function tests**
In this commit we introduce a way to add additional datasets to the default dataset (seed).
Point of these additional datasets is that they can be reused and also they won't otherwise
affect other tests. E.g. if you need to add standard priority sunday timetable set for January
2025 for a test, you can add an additional dataset file which has all the necessary data for it.
The old way would have been to either add it to the default dataset, which would break many
existing tests, because they rely that the data is not changed.
Also add tests for 'vehicle_service.get_timetables_and_substitute_operating_days' and
'vehicle_service.get_timetable_versions_by_journey_pattern_ids'

Resolves https://github.com/HSLdevcom/jore4/issues/1295

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/186)
<!-- Reviewable:end -->
