### PR TITLE
Add substitute operating period

### DIFF
--- a/metadata/hsl/databases/timetables/tables/substitute_operating_period.yaml
+++ b/metadata/hsl/databases/timetables/tables/substitute_operating_period.yaml
@@ -1,0 +1,11 @@
+table:
+  name: substitute_operating_period
+  schema: service_calendar
+array_relationships:
+  - name: substitute_operating_day_by_line_types
+    using:
+      foreign_key_constraint_on:
+        column: substitute_operating_period_id
+        table:
+          name: substitute_operating_day_by_line_type
+          schema: service_calendar

--- a/metadata/hsl/databases/timetables/tables/tables.yaml
+++ b/metadata/hsl/databases/timetables/tables/tables.yaml
@@ -1,3 +1,4 @@
 - "!include substitute_operating_day_by_line_type.yaml"
 - "!include return_value_timetable_version.yaml"
 - "!include return_value_vehicle_schedule.yaml"
+- "!include substitute_operating_period.yaml"

--- a/migrations/hsl/timetables/1683624912748_create_substitute_operating_period/down.sql
+++ b/migrations/hsl/timetables/1683624912748_create_substitute_operating_period/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    ONLY service_calendar.substitute_operating_day_by_line_type DROP COLUMN substitute_operating_period_id;
+
+DROP TABLE service_calendar.substitute_operating_period;

--- a/migrations/hsl/timetables/1683624912748_create_substitute_operating_period/up.sql
+++ b/migrations/hsl/timetables/1683624912748_create_substitute_operating_period/up.sql
@@ -1,0 +1,23 @@
+CREATE TABLE service_calendar.substitute_operating_period (
+    substitute_operating_period_id uuid DEFAULT gen_random_uuid(),
+    period_name text UNIQUE NOT NULL,
+    is_preset boolean NOT NULL DEFAULT FALSE
+);
+
+ALTER TABLE ONLY service_calendar.substitute_operating_period
+ADD CONSTRAINT substitute_operating_period_pkey PRIMARY KEY (substitute_operating_period_id);
+
+COMMENT ON TABLE service_calendar.substitute_operating_period IS 'Models substitute operating period that consists of substitute operating days by line types.';
+COMMENT ON COLUMN service_calendar.substitute_operating_period.period_name IS 'Substitute operating period''s name';
+COMMENT ON COLUMN service_calendar.substitute_operating_period.is_preset IS 'Flag indicating whether operating period is preset or not. Preset operating periods have restrictions on the UI';
+
+ALTER TABLE ONLY service_calendar.substitute_operating_day_by_line_type
+ADD COLUMN substitute_operating_period_id uuid NOT NULL;
+
+ALTER TABLE ONLY service_calendar.substitute_operating_day_by_line_type
+ADD CONSTRAINT substitute_operating_day_by_line_type_substitute_period_fkey FOREIGN KEY (substitute_operating_period_id) REFERENCES service_calendar.substitute_operating_period(substitute_operating_period_id) ON DELETE CASCADE;
+
+CREATE INDEX substitute_operating_day_by_line_type_substitute_period
+ON service_calendar.substitute_operating_day_by_line_type USING btree (substitute_operating_period_id);
+
+COMMENT ON COLUMN service_calendar.substitute_operating_day_by_line_type.substitute_operating_period_id IS 'The id of the substitute operating period';

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/expressBusServiceSaturday20230520.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/expressBusServiceSaturday20230520.ts
@@ -8,10 +8,21 @@ export const expressBusServiceSaturday20230520SubstituteOperatingDayByLineType =
       '0967a31a-8304-4440-9a8e-18bb67b281a8',
     type_of_line: TypeOfLine.ExpressBusService,
     superseded_date: DateTime.fromISO('2023-05-20'),
+    substitute_operating_period_id: 'b3dc5a95-74a1-42ed-b428-b633d8cc1563',
   };
+
+export const expressBusServiceSaturday20230520SubstituteOperatingPeriod = {
+  substitute_operating_period_id: 'b3dc5a95-74a1-42ed-b428-b633d8cc1563',
+  is_preset: false,
+  period_name: 'Unusual Saturday for Express Bus Service',
+};
 
 export const expressBusServiceSaturday20230520Dataset: TableData<HslTimetablesDbTables>[] =
   [
+    {
+      name: 'service_calendar.substitute_operating_period',
+      data: [expressBusServiceSaturday20230520SubstituteOperatingPeriod],
+    },
     {
       name: 'service_calendar.substitute_operating_day_by_line_type',
       data: [expressBusServiceSaturday20230520SubstituteOperatingDayByLineType],

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/stoppingBusServiceSaturday20230520.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/stoppingBusServiceSaturday20230520.ts
@@ -8,10 +8,21 @@ export const stoppingBusServiceSaturday20230520SubstituteOperatingDayByLineType 
       '88fbc283-9552-45d2-9365-60272f1e44f6',
     type_of_line: TypeOfLine.StoppingBusService,
     superseded_date: DateTime.fromISO('2023-05-20'),
+    substitute_operating_period_id: 'cfa58eec-2e5a-4ab7-a8e9-a92a46316640',
   };
+
+export const stoppingBusServiceSaturday20230520SubstituteOperatingPeriod = {
+  substitute_operating_period_id: 'cfa58eec-2e5a-4ab7-a8e9-a92a46316640',
+  is_preset: false,
+  period_name: 'Unusual Saturday for Stopping Bus Service',
+};
 
 export const stoppingBusServiceSaturday20230520Dataset: TableData<HslTimetablesDbTables>[] =
   [
+    {
+      name: 'service_calendar.substitute_operating_period',
+      data: [stoppingBusServiceSaturday20230520SubstituteOperatingPeriod],
+    },
     {
       name: 'service_calendar.substitute_operating_day_by_line_type',
       data: [

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/stoppingBusServiceThursday20230406.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/substitute-operating-days-by-line-types/stoppingBusServiceThursday20230406.ts
@@ -10,10 +10,21 @@ export const stoppingBusServiceThursday20230406SubstituteOperatingDayByLineType 
     type_of_line: TypeOfLine.StoppingBusService,
     superseded_date: DateTime.fromISO('2023-04-06'),
     substitute_day_of_week: DayOfWeek.Sunday,
+    substitute_operating_period_id: 'c23c96ba-2ef5-4e0c-a3fd-9e514432d638',
   };
+
+export const stoppingBusServiceThursday20230406SubstituteOperatingPeriod = {
+  substitute_operating_period_id: 'c23c96ba-2ef5-4e0c-a3fd-9e514432d638',
+  is_preset: false,
+  period_name: "Joe Biden's Visit",
+};
 
 export const stoppingBusServiceSaturday20230406Dataset: TableData<HslTimetablesDbTables>[] =
   [
+    {
+      name: 'service_calendar.substitute_operating_period',
+      data: [stoppingBusServiceThursday20230406SubstituteOperatingPeriod],
+    },
     {
       name: 'service_calendar.substitute_operating_day_by_line_type',
       data: [

--- a/test/hasura/hsl/timetablesdb/datasets/additional-sets/utils.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/additional-sets/utils.ts
@@ -52,6 +52,10 @@ export const getDbDataWithAdditionalDatasets = ({
           datasets,
           'service_calendar.substitute_operating_day_by_line_type',
         ),
+        getCombinedData(
+          datasets,
+          'service_calendar.substitute_operating_period',
+        ),
       ],
       (tableSchema) => tableSchema.name,
     ),

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/index.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/index.ts
@@ -1,3 +1,4 @@
 export * from './substitute-operating-day-by-line-types';
+export * from './substitute-operating-periods';
 export * from './table-data';
 export * from './vehicle-schedule-frames';

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-day-by-line-types.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-day-by-line-types.ts
@@ -9,6 +9,7 @@ export const substituteOperatingDayByLineTypesByName = {
     type_of_line: TypeOfLine.StoppingBusService,
     superseded_date: DateTime.fromISO('2023-04-01'),
     substitute_day_of_week: DayOfWeek.Friday,
+    substitute_operating_period_id: 'e2df8923-6641-474e-a355-d531e8433888',
   },
 };
 

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-periods.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/substitute-operating-periods.ts
@@ -1,0 +1,11 @@
+import { SubstituteOperatingPeriod } from '../types';
+
+export const substituteOperatingPeriodByNames = {
+  aprilFools: {
+    substitute_operating_period_id: 'e2df8923-6641-474e-a355-d531e8433888',
+    is_preset: false,
+    period_name: 'AprilFools substitute operating period',
+  },
+};
+export const substituteOperatingPeriod: SubstituteOperatingPeriod[] =
+  Object.values(substituteOperatingPeriodByNames);

--- a/test/hasura/hsl/timetablesdb/datasets/defaultSetup/table-data.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/defaultSetup/table-data.ts
@@ -2,6 +2,7 @@ import { mergeLists } from '@util/schema';
 import { defaultGenericTimetablesDbData } from 'generic/timetablesdb/datasets/defaultSetup';
 import { HslTimetablesDbTables } from '../schema';
 import { substituteOperatingDayByLineTypes } from './substitute-operating-day-by-line-types';
+import { substituteOperatingPeriod } from './substitute-operating-periods';
 import { hslVehicleJourneys } from './vehicle-journeys';
 import { hslVehicleScheduleFrames } from './vehicle-schedule-frames';
 import { hslVehicleServices } from './vehicle-services';
@@ -27,6 +28,10 @@ export const defaultHslTimetablesDbData: TableData<HslTimetablesDbTables>[] = [
     ],
     (tableSchema) => tableSchema.name,
   ),
+  {
+    name: 'service_calendar.substitute_operating_period',
+    data: substituteOperatingPeriod,
+  },
   {
     name: 'service_calendar.substitute_operating_day_by_line_type',
     data: substituteOperatingDayByLineTypes,

--- a/test/hasura/hsl/timetablesdb/datasets/schema.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/schema.ts
@@ -2,11 +2,15 @@ import {
   genericTimetablesDbSchema,
   genericTimetablesDbTables,
 } from 'generic/timetablesdb/datasets/schema';
-import { substituteOperatingDayByLineTypeProps } from './types';
+import {
+  SubstituteOperatingPeriodProps,
+  substituteOperatingDayByLineTypeProps,
+} from './types';
 
 export const hslTimetablesDbTables = [
   ...genericTimetablesDbTables,
   'service_calendar.substitute_operating_day_by_line_type',
+  'service_calendar.substitute_operating_period',
 ] as const;
 export type HslTimetablesDbTables = (typeof hslTimetablesDbTables)[number];
 
@@ -15,5 +19,9 @@ export const hslTimetablesDbSchema: TableSchemaMap<HslTimetablesDbTables> = {
   'service_calendar.substitute_operating_day_by_line_type': {
     name: 'service_calendar.substitute_operating_day_by_line_type',
     props: substituteOperatingDayByLineTypeProps,
+  },
+  'service_calendar.substitute_operating_period': {
+    name: 'service_calendar.substitute_operating_period',
+    props: SubstituteOperatingPeriodProps,
   },
 };

--- a/test/hasura/hsl/timetablesdb/datasets/types.ts
+++ b/test/hasura/hsl/timetablesdb/datasets/types.ts
@@ -30,6 +30,13 @@ export const substituteOperatingDayByLineTypeProps: Property[] = [
   'timezone',
   'begin_datetime',
   'end_datetime',
+  'substitute_operating_period_id',
+];
+
+export const SubstituteOperatingPeriodProps: Property[] = [
+  'substitute_operating_period_id',
+  'period_name',
+  'is_preset',
 ];
 
 export type SubstituteOperatingDayByLineType = {
@@ -42,6 +49,7 @@ export type SubstituteOperatingDayByLineType = {
   timezone?: string;
   begin_datetime?: DateTime;
   end_datetime?: DateTime;
+  substitute_operating_period_id: UUID;
 };
 
 export type TimetableVersion = {
@@ -63,4 +71,10 @@ export type VehicleSchedule = {
   validity_start: DateTime;
   validity_end: DateTime;
   created_at: DateTime;
+};
+
+export type SubstituteOperatingPeriod = {
+  substitute_operating_period_id: UUID;
+  period_name: string;
+  is_preset: boolean;
 };

--- a/test/hasura/hsl/timetablesdb/integration-tests/function-get_vehicle_schedules_on_date/get-vehicle-schedules-on-date.spec.ts
+++ b/test/hasura/hsl/timetablesdb/integration-tests/function-get_vehicle_schedules_on_date/get-vehicle-schedules-on-date.spec.ts
@@ -18,6 +18,7 @@ import {
   stagingSunApril2024Dataset,
   stoppingBusServiceSaturday20230520Dataset,
   stoppingBusServiceSaturday20230520SubstituteOperatingDayByLineType,
+  stoppingBusServiceSaturday20230520SubstituteOperatingPeriod,
   temporarySatFirstHalfApril2023Dataset,
   temporarySatFirstHalfApril2023VehicleJourneysByName,
   temporarySatFirstHalfApril2023VehicleScheduleFrame,
@@ -812,6 +813,12 @@ describe('Function get_timetables_and_substitute_operating_days', () => {
                   datasets: [
                     [
                       {
+                        name: 'service_calendar.substitute_operating_period',
+                        data: [
+                          stoppingBusServiceSaturday20230520SubstituteOperatingPeriod,
+                        ],
+                      },
+                      {
                         name: 'service_calendar.substitute_operating_day_by_line_type',
                         data: [
                           {
@@ -896,6 +903,12 @@ describe('Function get_timetables_and_substitute_operating_days', () => {
                 getDbDataWithAdditionalDatasets({
                   datasets: [
                     [
+                      {
+                        name: 'service_calendar.substitute_operating_period',
+                        data: [
+                          stoppingBusServiceSaturday20230520SubstituteOperatingPeriod,
+                        ],
+                      },
                       {
                         name: 'service_calendar.substitute_operating_day_by_line_type',
                         data: [
@@ -983,6 +996,12 @@ describe('Function get_timetables_and_substitute_operating_days', () => {
                 getDbDataWithAdditionalDatasets({
                   datasets: [
                     [
+                      {
+                        name: 'service_calendar.substitute_operating_period',
+                        data: [
+                          stoppingBusServiceSaturday20230520SubstituteOperatingPeriod,
+                        ],
+                      },
                       {
                         name: 'service_calendar.substitute_operating_day_by_line_type',
                         data: [
@@ -1080,6 +1099,12 @@ describe('Function get_timetables_and_substitute_operating_days', () => {
                   datasets: [
                     [
                       {
+                        name: 'service_calendar.substitute_operating_period',
+                        data: [
+                          stoppingBusServiceSaturday20230520SubstituteOperatingPeriod,
+                        ],
+                      },
+                      {
                         name: 'service_calendar.substitute_operating_day_by_line_type',
                         data: [
                           {
@@ -1175,6 +1200,12 @@ describe('Function get_timetables_and_substitute_operating_days', () => {
                 getDbDataWithAdditionalDatasets({
                   datasets: [
                     [
+                      {
+                        name: 'service_calendar.substitute_operating_period',
+                        data: [
+                          stoppingBusServiceSaturday20230520SubstituteOperatingPeriod,
+                        ],
+                      },
                       {
                         name: 'service_calendar.substitute_operating_day_by_line_type',
                         data: [


### PR DESCRIPTION
- New table `service_calendar.substitute_operating_period` to group `substitute_operating_days` 
- New view `service_calendar.substitute_operating_period_with_date_range` to get periods with date range and linetypes
- New function `service_calendar.save_operating_periods` handles saving/updating `substitute_operating_days` for `substitute_operating_periods`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/188)
<!-- Reviewable:end -->
