### PR TITLE
Remove timetables-namespace

### DIFF
--- a/metadata/generic/databases/databases.yaml
+++ b/metadata/generic/databases/databases.yaml
@@ -29,7 +29,6 @@
   customization:
     naming_convention: hasura-default
     root_fields:
-      namespace: timetables
       prefix: timetables_
     type_names:
       prefix: timetables_

--- a/test/hasura/generic/timetablesdb/integration-tests/example.spec.ts
+++ b/test/hasura/generic/timetablesdb/integration-tests/example.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { hasuraRequestTemplate, timetablesDbConfig } from '@config';
 import { asGraphQlDateObject, toGraphQlObject } from '@util/dataset';
-import { closeDbConnection, createDbConnection, DbConnection } from '@util/db';
+import { DbConnection, closeDbConnection, createDbConnection } from '@util/db';
 import { buildPropNameArray, queryTable, setupDb } from '@util/setup';
 import { DateTime } from 'luxon';
 import { post } from 'request-promise';
@@ -25,17 +25,13 @@ const toBeInserted: Partial<VehicleScheduleFrame> = {
 
 const buildMutation = (scheduleFrame: Partial<VehicleScheduleFrame>) => `
   mutation {
-    timetables {
-      timetables_insert_vehicle_schedule_vehicle_schedule_frame(objects: ${toGraphQlObject(
-        scheduleFrame,
-      )}) {
-        returning {
-          ${buildPropNameArray(
-            genericTimetablesDbSchema[
-              'vehicle_schedule.vehicle_schedule_frame'
-            ],
-          )}
-        }
+    timetables_insert_vehicle_schedule_vehicle_schedule_frame(objects: ${toGraphQlObject(
+      scheduleFrame,
+    )}) {
+      returning {
+        ${buildPropNameArray(
+          genericTimetablesDbSchema['vehicle_schedule.vehicle_schedule_frame'],
+        )}
       }
     }
   }

--- a/test/hasura/generic/timetablesdb/mutations.ts
+++ b/test/hasura/generic/timetablesdb/mutations.ts
@@ -20,7 +20,6 @@ export const buildUpdateVehicleScheduleFrameMutation = (
   vehicleScheduleFrameId: UUID,
   toBeUpdated: Partial<VehicleScheduleFrame>,
 ) => `
-  timetables {
     timetables_update_vehicle_schedule_vehicle_schedule_frame(
       where: {
         vehicle_schedule_frame_id: {_eq: "${vehicleScheduleFrameId}"}
@@ -31,7 +30,7 @@ export const buildUpdateVehicleScheduleFrameMutation = (
         ${buildPropNameArray(
           genericTimetablesDbSchema['vehicle_schedule.vehicle_schedule_frame'],
         )}
-      }
+      
     }
   }
 `;
@@ -41,7 +40,7 @@ export const buildUpdateVehicleScheduleFrameMutation = (
 export const buildInsertVehicleServiceMutation = (
   newVehicleService: VehicleService,
 ) => `
-  timetables {
+  
     timetables_insert_vehicle_service_vehicle_service(objects: ${toGraphQlObject(
       newVehicleService,
     )}) {
@@ -49,7 +48,7 @@ export const buildInsertVehicleServiceMutation = (
         ${buildPropNameArray(
           genericTimetablesDbSchema['vehicle_service.vehicle_service'],
         )}
-      }
+      
     }
   }
 `;
@@ -58,7 +57,7 @@ export const buildUpdateVehicleServiceMutation = (
   vehicleServiceId: UUID,
   toBeUpdated: Partial<VehicleService>,
 ) => `
-  timetables {
+  
     timetables_update_vehicle_service_vehicle_service(
       where: {
         vehicle_service_id: {_eq: "${vehicleServiceId}"}
@@ -69,7 +68,7 @@ export const buildUpdateVehicleServiceMutation = (
         ${buildPropNameArray(
           genericTimetablesDbSchema['vehicle_service.vehicle_service'],
         )}
-      }
+      
     }
   }
 `;
@@ -80,7 +79,7 @@ export const buildUpdateBlockMutation = (
   blockId: UUID,
   toBeUpdated: Partial<VehicleServiceBlock>,
 ) => `
-  timetables {
+  
     timetables_update_vehicle_service_block(
       where: {
         block_id: {_eq: "${blockId}"}
@@ -92,7 +91,7 @@ export const buildUpdateBlockMutation = (
           genericTimetablesDbSchema['vehicle_service.block'],
         )}
       }
-    }
+    
   }
 `;
 
@@ -101,7 +100,7 @@ export const buildUpdateBlockMutation = (
 export const buildInsertVehicleJourneyMutation = (
   newVehicleJourney: VehicleJourney,
 ) => `
-  timetables {
+  
     timetables_insert_vehicle_journey_vehicle_journey(objects: ${toGraphQlObject(
       newVehicleJourney,
     )}) {
@@ -110,7 +109,7 @@ export const buildInsertVehicleJourneyMutation = (
           genericTimetablesDbSchema['vehicle_journey.vehicle_journey'],
         )}
       }
-    }
+    
   }
 `;
 
@@ -118,7 +117,7 @@ export const buildUpdateVehicleJourneyMutation = (
   vehicleJourneyId: UUID,
   toBeUpdated: Partial<VehicleJourney>,
 ) => `
-  timetables {
+  
     timetables_update_vehicle_journey_vehicle_journey(
       where: {
         vehicle_journey_id: {_eq: "${vehicleJourneyId}"}
@@ -129,20 +128,20 @@ export const buildUpdateVehicleJourneyMutation = (
         ${buildPropNameArray(
           genericTimetablesDbSchema['vehicle_journey.vehicle_journey'],
         )}
-      }
+      
     }
   }
 `;
 
 export const buildDeleteVehicleJourneyMutation = (vehicleJourneyId: UUID) => `
-  timetables {
+  
     timetables_delete_vehicle_journey_vehicle_journey(
       where: {
         vehicle_journey_id: {_eq: "${vehicleJourneyId}"}
       }
     ) {
       affected_rows
-    }
+    
   }
 `;
 
@@ -152,7 +151,7 @@ export const buildUpdateJourneyPatternRefMutation = (
   journeyPatternRefId: UUID,
   toBeUpdated: Partial<JourneyPatternRef>,
 ) => `
-  timetables {
+  
     timetables_update_journey_pattern_journey_pattern_ref(
       where: {
         journey_pattern_ref_id: {_eq: "${journeyPatternRefId}"}
@@ -164,20 +163,20 @@ export const buildUpdateJourneyPatternRefMutation = (
           genericTimetablesDbSchema['journey_pattern.journey_pattern_ref'],
         )}
       }
-    }
+    
   }
 `;
 
 // timetabled_passing_time:
 
 export const buildDeletePassingTimeMutation = (vehicleJourneyId: UUID) => `
-  timetables {
+  
       timetables_delete_passing_times_timetabled_passing_time(
         where: {
           vehicle_journey_id: {_eq: "${vehicleJourneyId}"}
         }
       ) {
         affected_rows
-      }
+      
     }
 `;


### PR DESCRIPTION
Adding namespace for Timetables breaks transaction when used from Apollo Client...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/190)
<!-- Reviewable:end -->
