### PR TITLE
Add substitute period validity range to schedule calculations

### DIFF
--- a/migrations/generic/timetables/1000000000000_R_before_migrate/down.sql
+++ b/migrations/generic/timetables/1000000000000_R_before_migrate/down.sql
@@ -7,3 +7,4 @@ DROP SCHEMA vehicle_service;
 DROP SCHEMA vehicle_journey;
 DROP SCHEMA passing_times;
 DROP SCHEMA return_value;
+DROP SCHEMA internal_service_calendar;

--- a/migrations/generic/timetables/1000000000000_R_before_migrate/up.sql
+++ b/migrations/generic/timetables/1000000000000_R_before_migrate/up.sql
@@ -1,43 +1,48 @@
 -- create schemas if they don't yet exist, because the drop function below reference them
 CREATE SCHEMA IF NOT EXISTS route;
-COMMENT ON SCHEMA route 
+COMMENT ON SCHEMA route
 IS 'The route model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=2:1:3:416';
 
 CREATE SCHEMA IF NOT EXISTS journey_pattern;
-COMMENT ON SCHEMA journey_pattern 
+COMMENT ON SCHEMA journey_pattern
 IS 'The journey pattern model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:1:683 ';
 
 CREATE SCHEMA IF NOT EXISTS service_pattern;
-COMMENT ON SCHEMA service_pattern 
+COMMENT ON SCHEMA service_pattern
 IS 'The service pattern model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=2:3:4:723 ';
 
 CREATE SCHEMA IF NOT EXISTS service_calendar;
-COMMENT ON SCHEMA service_calendar 
+COMMENT ON SCHEMA service_calendar
 IS 'The service calendar model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=1:6:3:294 ';
 
 CREATE SCHEMA IF NOT EXISTS vehicle_schedule;
-COMMENT ON SCHEMA vehicle_schedule 
+COMMENT ON SCHEMA vehicle_schedule
 IS 'The vehicle schedule frame adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:7:2:993 ';
 
 CREATE SCHEMA IF NOT EXISTS vehicle_service;
-COMMENT ON SCHEMA vehicle_service 
+COMMENT ON SCHEMA vehicle_service
 IS 'The vehicle service model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:5:947 ';
 
 CREATE SCHEMA IF NOT EXISTS vehicle_journey;
-COMMENT ON SCHEMA vehicle_journey 
+COMMENT ON SCHEMA vehicle_journey
 IS 'The vehicle journey model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:1:1:824 ';
 
 CREATE SCHEMA IF NOT EXISTS passing_times;
-COMMENT ON SCHEMA passing_times 
+COMMENT ON SCHEMA passing_times
 IS 'The passing times model adapted from Transmodel: https://www.transmodel-cen.eu/model/index.htm?goto=3:4:939 ';
 
 CREATE SCHEMA IF NOT EXISTS internal_utils;
-COMMENT ON SCHEMA internal_utils 
-IS 'General utilities';
+COMMENT ON SCHEMA internal_utils
+IS 'Internal general utilities. Functions in this schema are not exposed to GraphQL API, hence the prefix.';
 
 CREATE SCHEMA IF NOT EXISTS return_value;
-COMMENT ON SCHEMA return_value 
+COMMENT ON SCHEMA return_value
 IS 'This schema is used for all the SQL functions that need to have a table as return value. Nothing is stored in the tables in this schema.';
+
+CREATE SCHEMA IF NOT EXISTS internal_service_calendar;
+COMMENT ON SCHEMA internal_service_calendar
+IS 'This schema is used for the internal SQL functions that are related to service_calendar schema. These internal functions are
+not exposed to GraphQL API, hence the prefix.';
 
 -- drop all triggers in jore4 schemas
 -- note: information_schema.triggers is missing TRUNCATE triggers

--- a/migrations/timetablesdb-dump.sql
+++ b/migrations/timetablesdb-dump.sql
@@ -26,10 +26,17 @@ COMMENT ON EXTENSION btree_gist IS 'support for indexing common datatypes in GiS
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
 
 --
+-- Name: SCHEMA internal_service_calendar; Type: COMMENT; Schema: -; Owner: dbhasura
+--
+
+COMMENT ON SCHEMA internal_service_calendar IS 'This schema is used for the internal SQL functions that are related to service_calendar schema. These internal functions are
+not exposed to GraphQL API, hence the prefix.';
+
+--
 -- Name: SCHEMA internal_utils; Type: COMMENT; Schema: -; Owner: dbhasura
 --
 
-COMMENT ON SCHEMA internal_utils IS 'General utilities';
+COMMENT ON SCHEMA internal_utils IS 'Internal general utilities. Functions in this schema are not exposed to GraphQL API, hence the prefix.';
 
 --
 -- Name: SCHEMA journey_pattern; Type: COMMENT; Schema: -; Owner: dbhasura
@@ -1662,6 +1669,15 @@ CREATE INDEX idx_vehicle_service_vehicle_schedule_frame ON vehicle_service.vehic
 --
 
 CREATE UNIQUE INDEX vehicle_type_label_idx ON vehicle_type.vehicle_type USING btree (label);
+
+--
+-- Name: internal_service_calendar; Type: SCHEMA; Schema: -; Owner: dbhasura
+--
+
+CREATE SCHEMA internal_service_calendar;
+
+
+ALTER SCHEMA internal_service_calendar OWNER TO dbhasura;
 
 --
 -- Name: internal_utils; Type: SCHEMA; Schema: -; Owner: dbhasura


### PR DESCRIPTION
This was two birds with one stone, first of all **the initial vsf.validity_start and vsf.validity_end were
wrong**, and caused the substitute operating day to show the validity of the target day instead
of the superseded_date. But also now we have the substitute operating period  implemented
and those can last multiple days and that is the real validity range.
 Also added the used internal_utils functions to calculate the begin and end date here.

Resolves HSLdevcom/jore4#1390

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/197)
<!-- Reviewable:end -->
