### PR TITLE
Remove fk constraints from return_value.timetable_version

### DIFF
--- a/migrations/hsl/timetables/1692783935710_remove_foreign_key_constraints_on_return_value_timetable_version/down.sql
+++ b/migrations/hsl/timetables/1692783935710_remove_foreign_key_constraints_on_return_value_timetable_version/down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE return_value.timetable_version
+  ADD CONSTRAINT timetable_version_vehicle_schedule_frame_id_fkey
+  FOREIGN KEY (vehicle_schedule_frame_id) REFERENCES vehicle_schedule.vehicle_schedule_frame(vehicle_schedule_frame_id);
+
+ALTER TABLE return_value.timetable_version
+  ADD CONSTRAINT timetable_version_substitute_operating_day_by_line_type_id_fkey
+  FOREIGN KEY (substitute_operating_day_by_line_type_id) REFERENCES service_calendar.substitute_operating_day_by_line_type(substitute_operating_day_by_line_type_id);
+
+ALTER TABLE return_value.timetable_version
+  ADD CONSTRAINT timetable_version_day_type_id_fkey
+  FOREIGN KEY (day_type_id) REFERENCES service_calendar.day_type(day_type_id);

--- a/migrations/hsl/timetables/1692783935710_remove_foreign_key_constraints_on_return_value_timetable_version/up.sql
+++ b/migrations/hsl/timetables/1692783935710_remove_foreign_key_constraints_on_return_value_timetable_version/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE return_value.timetable_version
+  DROP CONSTRAINT timetable_version_day_type_id_fkey;
+
+ALTER TABLE return_value.timetable_version
+  DROP CONSTRAINT timetable_version_substitute_operating_day_by_line_type_id_fkey;
+
+ALTER TABLE return_value.timetable_version
+  DROP CONSTRAINT timetable_version_vehicle_schedule_frame_id_fkey;


### PR DESCRIPTION
These return_value schema tables are only for function return values, and they should not be part of the data model via any constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/198)
<!-- Reviewable:end -->
