### PR TITLE
Add hardcoded ids to vehicle types populated in migrations

### DIFF
--- a/migrations/hsl/timetables/1679393480745_populate_hsl_vehicle_types_and_add_hsl_id_idx/up.sql
+++ b/migrations/hsl/timetables/1679393480745_populate_hsl_vehicle_types_and_add_hsl_id_idx/up.sql
@@ -1,22 +1,24 @@
 CREATE UNIQUE INDEX  vehicle_type_hsl_id_idx ON vehicle_type.vehicle_type USING btree(hsl_id);
 
-INSERT INTO vehicle_type.vehicle_type(label, description_i18n, hsl_id)
-VALUES ('Low multi-axle bus', '{"fi_FI": "Matala telibussi"}', 0),
-('High 2-axle bus', '{"fi_FI": "Korkea 2-akselinen bussi"}', 1),
-('High articulated bus', '{"fi_FI": "Korkea nivelbussi"}', 2),
-('Low A1 bus', '{"fi_FI": "Matala A1 -bussi"}', 3),
-('Euro 4 2-axle', '{"fi_FI": "Euro 4 2-aks"}', 7),
-('Low articulated bus', '{"fi_FI": "Matala nivelbussi"}', 8),
-('Low midibus', '{"fi_FI": "Matala midibussi"}', 9),
-('Euro 4 multi-axle', '{"fi_FI": "Euro 4 teli"}', 10),
-('High gasbus', '{"fi_FI": "Korkea kaasubussi"}', 11),
-('Mini A', '{"fi_FI": "Mini A"}', 12),
-('Mini B', '{"fi_FI": "Mini B"}', 13),
-('Mini Dab', '{"fi_FI": "Mini Dab"}', 14),
-('EEV 2-axle A1', '{"fi_FI": "EEV 2-akselinen A1"}', 15),
-('EEV Multi-axle bus', '{"fi_FI": "EEV Telibussi"}', 16),
-('Low A2 Bus', '{"fi_FI": "Matala A2 -bussi"}', 17),
-('High 43 seated', '{"fi_FI": "Korkea 43-paikkainen"}', 18),
-('2-Axled hybrid A1', '{"fi_FI": "2-akselinen hybridi A1"}', 20),
-('A1 electrical bus', '{"fi_FI": "A1 sähköbussi"}', 21),
-('A2 electrical bus', '{"fi_FI": "A2 sähköbussi"}', 22);
+INSERT INTO vehicle_type.vehicle_type
+  (vehicle_type_id, hsl_id, label, description_i18n)
+VALUES
+  ('27ed17a8-ac64-4f6a-b3e8-41c95d8ab153', 0, 'Low multi-axle bus', '{"fi_FI": "Matala telibussi"}'),
+  ('b51470c1-8cc7-4508-ac83-eaf8976d67e0', 1, 'High 2-axle bus', '{"fi_FI": "Korkea 2-akselinen bussi"}'),
+  ('5705e3de-bea4-4cb3-ac50-76c6332898d1', 2, 'High articulated bus', '{"fi_FI": "Korkea nivelbussi"}'),
+  ('9e431f63-1925-45a6-a222-cad58d339da9', 3, 'Low A1 bus', '{"fi_FI": "Matala A1 -bussi"}'),
+  ('60db118d-db21-44da-acf5-08f569372373', 7, 'Euro 4 2-axle', '{"fi_FI": "Euro 4 2-aks"}'),
+  ('91f63622-044f-4280-be6a-f75cb8311557', 8, 'Low articulated bus', '{"fi_FI": "Matala nivelbussi"}'),
+  ('5cb94060-73db-41b6-a892-23cbc13da816', 9, 'Low midibus', '{"fi_FI": "Matala midibussi"}'),
+  ('92d8179d-1f79-424d-97b8-688be3f2e85d', 10, 'Euro 4 multi-axle', '{"fi_FI": "Euro 4 teli"}'),
+  ('0942ff2e-d3ba-4652-b4aa-911835c60011', 11, 'High gasbus', '{"fi_FI": "Korkea kaasubussi"}'),
+  ('b24f8f2d-bb9e-48ed-a9e8-96abe27a4549', 12, 'Mini A', '{"fi_FI": "Mini A"}'),
+  ('78162473-168b-487e-a4d7-2195e90ac1b7', 13, 'Mini B', '{"fi_FI": "Mini B"}'),
+  ('67cf53ca-7edb-4ed1-a8b1-71d6d58afbc9', 14, 'Mini Dab', '{"fi_FI": "Mini Dab"}'),
+  ('3dc05ccb-d3d8-431e-911f-9e8bf4de9b82', 15, 'EEV 2-axle A1', '{"fi_FI": "EEV 2-akselinen A1"}'),
+  ('6acaa0a6-d260-453c-a7a4-d7be3714d26a', 16, 'EEV Multi-axle bus', '{"fi_FI": "EEV Telibussi"}'),
+  ('e3475423-c8ae-4a41-b9ac-0dce4a29ba25', 17, 'Low A2 Bus', '{"fi_FI": "Matala A2 -bussi"}'),
+  ('bdf8bd2c-7166-4b60-b8cd-0eb95bba6919', 18, 'High 43 seated', '{"fi_FI": "Korkea 43-paikkainen"}'),
+  ('5a053aa9-e4d7-4a6e-8586-06645f8be8c2', 20, '2-Axled hybrid A1', '{"fi_FI": "2-akselinen hybridi A1"}'),
+  ('3590c14b-8a05-449c-bf74-2031ec277651', 21, 'A1 electrical bus', '{"fi_FI": "A1 sähköbussi"}'),
+  ('55b5784f-5805-46eb-a842-a25fce9eb560', 22, 'A2 electrical bus', '{"fi_FI": "A2 sähköbussi"}');


### PR DESCRIPTION
These missing meant that vehicle types got a random UUID each time. This makes creating test data a bit more difficult sometimes, because for blocks the vehicle_type_id is a required value. One example of this is the test-db-manager seed script, which has to fetch vehicle types from a running DB before it can create the seed data. If we hard code the ids, we can just use known values in such test code.

We already do this kind of hard coded UUIDs for values populated in migrations at least for service_calendar.day_type and service_calendar.day_type_active_on_day_of_week tables.

This only affects new databases and not eg. our test (demo) environment, but that is fine, since this fix is meant to address issues in test data and the id values are not relied upon in any app code.

There didn't seem to be any other tables that had a similar issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/220)
<!-- Reviewable:end -->
