### PR TITLE
Use seed-infrastructure-links-v2 in github workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,7 +90,7 @@ jobs:
           hasura_version: '${{ env.IMAGE_NAME }}:hsl-${{ env.COMMIT_ID }}'
 
       - name: Seed infrastructure links
-        uses: HSLdevcom/jore4-tools/github-actions/seed-infrastructure-links@seed-infrastructure-links-v1
+        uses: HSLdevcom/jore4-tools/github-actions/seed-infrastructure-links@seed-infrastructure-links-v2
 
       - name: Run e2e tests
         uses: HSLdevcom/jore4-tools/github-actions/run-cypress-tests@run-cypress-tests-v1


### PR DESCRIPTION
seed-infrastructure-links-v1 no longer works due to it using the removed e2e1 database. Update to v2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/224)
<!-- Reviewable:end -->
