### PR TITLE
Add stop_place_newest_version metadata

### DIFF
--- a/metadata/hsl/databases/stops/tables/public_stop_place_newest_version.yaml
+++ b/metadata/hsl/databases/stops/tables/public_stop_place_newest_version.yaml
@@ -1,0 +1,88 @@
+table:
+  name: stop_place_newest_version
+  schema: public
+array_relationships:
+  - name: stop_place_access_spaces
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_access_spaces
+          schema: public
+  - name: stop_place_alternative_names
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_alternative_names
+          schema: public
+  - name: stop_place_children
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_children
+          schema: public
+  - name: stop_place_equipment_places
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_equipment_places
+          schema: public
+  - name: stop_place_key_values
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_key_values
+          schema: public
+  - name: stop_place_quays
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_quays
+          schema: public
+  - name: stop_place_tariff_zones
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_tariff_zones
+          schema: public
+remote_relationships:
+  - definition:
+      to_remote_schema:
+        lhs_fields:
+          - netex_id
+        remote_field:
+          stopPlace:
+            arguments:
+              id: $netex_id
+        remote_schema: Tiamat
+    name: TiamatStopPlace
+  - definition:
+      to_source:
+        field_mapping:
+          netex_id: stop_place_ref
+        relationship_type: object
+        source: default
+        table:
+          name: scheduled_stop_point
+          schema: service_pattern
+    name: scheduled_stop_point_instance

--- a/metadata/hsl/databases/stops/tables/tables.yaml
+++ b/metadata/hsl/databases/stops/tables/tables.yaml
@@ -77,6 +77,7 @@
 - "!include public_schema_version.yaml"
 - "!include public_spatial_ref_sys.yaml"
 - "!include public_stop_place.yaml"
+- "!include public_stop_place_newest_version.yaml"
 - "!include public_stop_place_access_spaces.yaml"
 - "!include public_stop_place_adjacent_sites.yaml"
 - "!include public_stop_place_alternative_names.yaml"


### PR DESCRIPTION
Add the necessary metadata to track stop_place_newest_version which
is a view that only has the newest versions of a stop (distincted by netex_id).
Also add the necessary relationships, a remote relationship to tiamat API
stop place and remote relationship to scheduled_stop_point. We might have
use for both, or only one of these remote relationships, but should be
no harm in adding both.

Resolves https://dev.azure.com/hslfi/JORE%204.0/_workitems/edit/35459

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/227)
<!-- Reviewable:end -->
