### PR TITLE
Add join to newest StopPlace from newest Quay

### DIFF
--- a/metadata/hsl/databases/stops/tables/public_quay_newest_version.yaml
+++ b/metadata/hsl/databases/stops/tables/public_quay_newest_version.yaml
@@ -20,6 +20,15 @@ object_relationships:
         remote_table:
           name: stop_place
           schema: public
+  - name: stop_place_newest_version
+    using:
+      manual_configuration:
+        column_mapping:
+          stop_place_id: id
+        insertion_order: null
+        remote_table:
+          name: stop_place_newest_version
+          schema: public
 array_relationships:
   - name: quay_alternative_names
     using:


### PR DESCRIPTION
Provides same data as the more direct join to stop_place table, but as the stop_place table and stop_place_newest_version view are not the same DB table/view they are treated as 2 completely different types in the Graph. Thus, reusing code (fragments) between the 2 is not possible, and by default the UI code uses the stop_place_newest_version view for queries -> add a join to that.