### PR TITLE
Improve StopPlace child/parent joins

### DIFF
--- a/metadata/hsl/databases/stops/tables/public_stop_place_children.yaml
+++ b/metadata/hsl/databases/stops/tables/public_stop_place_children.yaml
@@ -2,6 +2,9 @@ table:
   name: stop_place_children
   schema: public
 object_relationships:
-  - name: stop_place
+  - name: child
     using:
       foreign_key_constraint_on: children_id
+  - name: parent
+    using:
+      foreign_key_constraint_on: stop_place_id

--- a/metadata/hsl/databases/stops/tables/public_stop_place_newest_version.yaml
+++ b/metadata/hsl/databases/stops/tables/public_stop_place_newest_version.yaml
@@ -1,7 +1,26 @@
 table:
   name: stop_place_newest_version
   schema: public
+object_relationships:
+  - name: parent
+    using:
+      manual_configuration:
+        column_mapping:
+          id: children_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_children
+          schema: public
 array_relationships:
+  - name: children
+    using:
+      manual_configuration:
+        column_mapping:
+          id: stop_place_id
+        insertion_order: null
+        remote_table:
+          name: stop_place_children
+          schema: public
   - name: group_of_stop_places_members
     using:
       manual_configuration:
@@ -28,15 +47,6 @@ array_relationships:
         insertion_order: null
         remote_table:
           name: stop_place_alternative_names
-          schema: public
-  - name: stop_place_children
-    using:
-      manual_configuration:
-        column_mapping:
-          id: stop_place_id
-        insertion_order: null
-        remote_table:
-          name: stop_place_children
           schema: public
   - name: stop_place_equipment_places
     using:


### PR DESCRIPTION
* Relate `stop_place_children` to both `parent` and the `child`.
* Relate `stop_place_children` as `children` and as `parent` on `stop_place_newest_version`