### PR TITLE
NewestStopPlace Timat link, only monomodal

### DIFF
--- a/metadata/hsl/databases/stops/tables/public_stop_place_newest_version.yaml
+++ b/metadata/hsl/databases/stops/tables/public_stop_place_newest_version.yaml
@@ -89,10 +89,12 @@ remote_relationships:
       to_remote_schema:
         lhs_fields:
           - netex_id
+          - is_area
         remote_field:
           stopPlace:
             arguments:
               id: $netex_id
+              onlyMonomodalStopPlaces: $is_area
         remote_schema: Tiamat
     name: TiamatStopPlace
   - definition:


### PR DESCRIPTION
onlyMonomodalStopPlaces parameter needs to be set to true, or else StopPlaces (StopAreas) that are part of a Terminal, cannot be queried, and will instead return the parent Terminal when requested by the id.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/262)
<!-- Reviewable:end -->
