### PR TITLE
Update StopRegistry/newestQuay related joins

### DIFF
--- a/metadata/hsl/databases/stops/tables/public_info_spot.yaml
+++ b/metadata/hsl/databases/stops/tables/public_info_spot.yaml
@@ -1,3 +1,11 @@
 table:
   name: info_spot
   schema: public
+array_relationships:
+  - name: locations
+    using:
+      foreign_key_constraint_on:
+        column: info_spot_id
+        table:
+          name: info_spot_location
+          schema: public

--- a/metadata/hsl/databases/stops/tables/public_info_spot_location.yaml
+++ b/metadata/hsl/databases/stops/tables/public_info_spot_location.yaml
@@ -1,0 +1,7 @@
+table:
+  name: info_spot_location
+  schema: public
+object_relationships:
+  - name: info_spot
+    using:
+      foreign_key_constraint_on: info_spot_id

--- a/metadata/hsl/databases/stops/tables/public_installed_equipment_version_structure_installed_equipment.yaml
+++ b/metadata/hsl/databases/stops/tables/public_installed_equipment_version_structure_installed_equipment.yaml
@@ -2,9 +2,9 @@ table:
   name: installed_equipment_version_structure_installed_equipment
   schema: public
 object_relationships:
-  - name: installedEquipmentVersionStructureByPlaceEquipmentId
-    using:
-      foreign_key_constraint_on: place_equipment_id
-  - name: installed_equipment_version_structure
+  - name: installed
     using:
       foreign_key_constraint_on: installed_equipment_id
+  - name: place
+    using:
+      foreign_key_constraint_on: place_equipment_id

--- a/metadata/hsl/databases/stops/tables/public_quay_newest_version.yaml
+++ b/metadata/hsl/databases/stops/tables/public_quay_newest_version.yaml
@@ -2,14 +2,14 @@ table:
   name: quay_newest_version
   schema: public
 object_relationships:
-  - name: equipment
+  - name: equipments
     using:
       manual_configuration:
         column_mapping:
-          place_equipments_id: id
+          place_equipments_id: place_equipment_id
         insertion_order: null
         remote_table:
-          name: place_equipment
+          name: installed_equipment_version_structure_installed_equipment
           schema: public
   - name: stopPlaceParent
     using:
@@ -39,6 +39,15 @@ object_relationships:
           name: stop_place_newest_version
           schema: public
 array_relationships:
+  - name: info_spot_locations
+    using:
+      manual_configuration:
+        column_mapping:
+          netex_id: location_netex_id
+        insertion_order: null
+        remote_table:
+          name: info_spot_location
+          schema: public
   - name: quay_alternative_names
     using:
       manual_configuration:

--- a/metadata/hsl/databases/stops/tables/tables.yaml
+++ b/metadata/hsl/databases/stops/tables/tables.yaml
@@ -38,6 +38,7 @@
 - "!include public_hsl_accessibility_properties.yaml"
 - "!include public_id_generator.yaml"
 - "!include public_info_spot.yaml"
+- "!include public_info_spot_location.yaml"
 - "!include public_info_spot_poster.yaml"
 - "!include public_installed_equipment.yaml"
 - "!include public_installed_equipment_version_structure.yaml"


### PR DESCRIPTION
* Track `info_spot_location`
* Link `info_spot_locations` to `info_spots` as `locations`
* Link InfoSpots to NewestQuay trough `info_spot_locations`
* `installed_equipment_version_structure_installed_equipment`
  - AS `ievsie`
  - Track the "parent" as `place`
  - Track the sub equipment pieces as `installed`
* `quay_newest_version.place_equipment_id`
  - Was linked to `place_equipment` view, which only allows direct access to the empty dtype=PlaceEquipment row.
  - Linked to `ievsie` as `equipments`, allowing access to the empty parent equipment as well as the child equipment pieces trough single join (Good for the search feature).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/270)
<!-- Reviewable:end -->
