### PR TITLE
Use unaligned output in psql query in repeateble-migrations.sh

### DIFF
--- a/scripts/repeatable-migrations.sh
+++ b/scripts/repeatable-migrations.sh
@@ -21,7 +21,7 @@ SELECT EXISTS (
 );
 EOF
 )
-HDB_CATALOG_EXISTS=`PGPASSWORD="${DB_PASSWORD}" ${PSQL_CMD} -t -c "${HDB_CATALOG_EXISTS_QUERY}"`
+HDB_CATALOG_EXISTS="$(PGPASSWORD="${DB_PASSWORD}" ${PSQL_CMD} -Atq -c "${HDB_CATALOG_EXISTS_QUERY}")"
 echo "HDB_CATALOG_EXISTS: $HDB_CATALOG_EXISTS"
 
 # 1. hdb catalog does not exist (yet), no need to tweak migrations. Exit with success


### PR DESCRIPTION
The query returned " t" on success and the following if always exited.

Changes:
- A (unaligned) eliminates the leading space padding — that was the original bug
- $() (command substitution) automatically strips trailing newlines

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-hasura/308)
<!-- Reviewable:end -->
